### PR TITLE
docs: rewrite TypeScript SDK docs and package copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,234 +1,168 @@
-# CLAUDE.md — Edictum JS
+# CLAUDE.md — Edictum TypeScript
 
-> Runtime rule enforcement for AI agent tool calls. TypeScript port of the edictum Python library with full feature parity.
+> Developer agent behavior platform for TypeScript. Write rules and workflows in YAML. Enforce them at the tool-call boundary.
 
-## What is Edictum
+## What Is In This Repo
 
-Runtime rule enforcement for AI agent tool calls. Deterministic pipeline: checks before execution, output checks after execution, session rules, principal-aware enforcement. Framework adapters (Vercel AI SDK, OpenAI Agents SDK, OpenClaw, Claude Agent SDK, LangChain.js). One runtime dep in core (js-yaml). Full feature parity with the Python library (`edictum` on PyPI, v0.15.0).
+Edictum for TypeScript ships the core rules engine, Workflow Gates runtime, server integration, and adapter packages for Vercel AI SDK, LangChain.js, OpenAI Agents SDK, and Claude Agent SDK. OpenClaw support lives in the separate `edictum-openclaw` repo.
 
-Current version: 0.3.0 (npm: `@edictum/core`)
+Current package versions: `@edictum/core` 0.3.2, `@edictum/server` 0.3.1, `@edictum/vercel-ai` 0.2.0, `@edictum/claude-sdk` 0.2.0, `@edictum/langchain` 0.2.0, `@edictum/openai-agents` 0.2.0, `@edictum/otel` 0.2.0
 
-## THE ONE RULE
+## The One Rule
 
-**`@edictum/core` runs fully standalone. No server dependency. No adapter dependency. No framework dependency.**
+**`@edictum/core` stays standalone. No server dependency. No adapter dependency. No framework dependency.**
 
-Core provides interfaces and implementations. The server package provides HTTP-backed implementations. Adapters are thin translation layers — rule enforcement logic stays in the pipeline.
+Core owns the rules engine and workflow runtime. The server package provides HTTP-backed implementations. Adapters are thin translation layers. Enforcement logic stays in the pipeline.
 
-## Architecture: Monorepo
+## Monorepo Layout
 
-```
+```text
 packages/
-├── core/              # @edictum/core — pipeline, rules, audit, session, YAML engine
+├── core/              # @edictum/core — pipeline, rules, decision log, session, YAML engine
 ├── vercel-ai/         # @edictum/vercel-ai — Vercel AI SDK adapter
 ├── openai-agents/     # @edictum/openai-agents — OpenAI Agents SDK adapter
-├── openclaw/          # @edictum/openclaw — OpenClaw adapter
 ├── claude-sdk/        # @edictum/claude-sdk — Claude Agent SDK adapter
 ├── langchain/         # @edictum/langchain — LangChain.js adapter
-└── server/            # @edictum/server — Server SDK (HTTP client, SSE, audit sink)
+├── otel/              # @edictum/otel — OpenTelemetry integration
+└── server/            # @edictum/server — server SDK (HTTP client, SSE, decision-log sink)
 ```
 
 ## Tech Stack
 
-| Layer           | Technology          | Rationale                                                      |
-| --------------- | ------------------- | -------------------------------------------------------------- |
-| Language        | TypeScript (strict) | Security product — type safety is non-negotiable               |
-| Runtime         | Node 22+ (LTS)      | Required by OpenClaw (P0 target), native fetch/structuredClone |
-| Build           | tsup (esbuild)      | Dual ESM+CJS output, ~10 lines config                          |
-| Test            | Vitest              | ESM-native, fast, good DX                                      |
-| Lint            | ESLint              | Largest plugin ecosystem, best for security rules              |
-| Package manager | pnpm                | Workspace monorepo support                                     |
-| Module format   | Dual ESM + CJS      | Maximum compatibility via tsup                                 |
+| Layer           | Technology          | Why                                                 |
+| --------------- | ------------------- | --------------------------------------------------- |
+| Language        | TypeScript (strict) | Type safety matters for an enforcement library      |
+| Runtime         | Node 22+            | Required by OpenClaw target and modern runtime APIs |
+| Build           | tsup                | Dual ESM + CJS output                               |
+| Test            | Vitest              | Fast and ESM-native                                 |
+| Lint            | ESLint              | Mature tooling and custom rule support              |
+| Package manager | pnpm                | Workspace monorepo support                          |
 
 ## Non-Negotiable Principles
 
-1. **Full feature parity with Python.** 147 features across 12 categories. Every feature has a parity test ID. If Python passes and TS fails, it's a bug.
-2. **Security is non-negotiable.** This is a security product. No shortcuts, no "good enough", no deferred fixes for vulnerabilities. Fail closed on every error path.
-3. **Minimal runtime deps in core.** js-yaml is a direct dependency. Optional: ajv, @opentelemetry/\*, @noble/ed25519.
-4. **Plain objects for rules.** Interfaces define the shape. TypeScript validates at compile time. No decorators, no builders, no hidden metadata.
-5. **All async.** Every pipeline, session, and audit sink method is async. No sync variants.
-6. **Immutability by default.** `ToolCall` is `Readonly<T>` + `Object.freeze()` + deep freeze. Principal is frozen. Rule state swaps atomically.
-7. **Adapters are thin.** All rule enforcement logic lives in `CheckPipeline`. Adapters only translate between framework input/output and the pipeline.
-8. **Adversarial tests before ship.** Every security boundary has bypass tests. Positive tests prove it works. Adversarial tests prove it doesn't break.
+1. **Full feature parity with Python.** If Python passes and TypeScript fails, it is a bug.
+2. **Fail closed.** Invalid input, storage errors, and evaluation errors must not silently allow tool calls.
+3. **Minimal runtime deps in core.** `js-yaml` is the only direct runtime dependency in `@edictum/core`.
+4. **Plain objects for rules.** No builders, decorators, or hidden metadata.
+5. **Async everywhere.** Pipeline, session, storage, approvals, and decision-log sinks are async.
+6. **Immutability by default.** Tool calls and snapshots are frozen.
+7. **Adapters stay thin.** They translate SDK callbacks to `CheckPipeline`; they do not invent new enforcement behavior.
+8. **Adversarial tests before ship.** Boundaries need bypass tests, not just happy-path tests.
 
 ## Coding Standards
 
 ### TypeScript
 
-- **TypeScript strict mode.** No `any` unless genuinely unavoidable and documented with a comment explaining why.
-- **`Readonly<T>` for immutable data.** All tool-call, decision, and violation types are readonly.
-- **`as const` + string literal unions** for enums. No TypeScript `enum` keyword.
-- **`interface` for protocols.** StorageBackend, AuditSink, ApprovalBackend are all interfaces.
-- **Async everywhere.** All pipeline, session, and audit sink methods are async.
-- **No classes unless necessary.** Prefer plain objects + functions. Use classes only for stateful things (Edictum, Session, Pipeline).
-- **Error hierarchy:** `EdictumError` (base) → `EdictumDenied`, `EdictumConfigError`, `EdictumToolError`.
-- **`structuredClone()`** for deep copy. No JSON roundtrip, no lodash.
-- **`Object.freeze()` + deep freeze** for immutable snapshots. Shallow freeze is insufficient for nested objects.
-- **No `asyncio.Lock` equivalent needed.** Node is single-threaded — Map operations are atomic.
+- **Strict mode.** No `any` unless unavoidable and documented.
+- **`Readonly<T>` for immutable data.** Tool-call, decision, and violation types are readonly.
+- **String literal unions over `enum`.**
+- **Interfaces for protocols.** `StorageBackend`, `AuditSink`, and `ApprovalBackend` stay interface-based.
+- **Async everywhere.**
+- **Classes only for stateful concerns.** `Edictum`, `Session`, and pipeline/runtime classes are fine.
+- **Use `structuredClone()` and deep freeze** for immutable snapshots.
 
 ### General
 
-- **Small, focused files (< 200 lines).** If a file grows past 200 lines, split it. Violations need explicit approval.
-- **Conventional commits** (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
-- **No premature abstraction.** Don't build extension points until there's a second user.
-- **No over-engineering.** Only make changes that are directly requested or clearly necessary.
+- **Keep files focused.** Split large files unless there is a good reason to keep the unit together.
+- **Use conventional commits.**
+- **Do not build abstraction for its own sake.**
+- **Make the smallest change that actually solves the problem.**
 
-## Rule API Design
+## Terminology
 
-Rules use **plain objects** with TypeScript interfaces. This is the most AI-friendly and most explicit API:
+In prose, use these terms:
 
-```typescript
-import { Decision, Edictum } from '@edictum/core'
-import type { Precondition } from '@edictum/core'
+- `rule`, `ruleset`, `tool call`, `blocked`, `violation`, `observe mode`
+- `Workflow Gates`, `decision log`, `dashboard`, `enforcement`
 
-const noRm: Precondition = {
-  tool: 'Bash',
-  check: async (toolCall) => {
-    if (toolCall.bashCommand?.includes('rm -rf')) return Decision.fail('Cannot run rm -rf')
-    return Decision.pass_()
-  },
-}
-
-const guard = new Edictum({ rules: [noRm] })
-```
-
-Why plain objects: full autocomplete, compile-time validation, no hidden state, serializable, most reliable for AI-generated code.
-
-## Terminology Enforcement
-
-Inherited from the M1 terminology guide. ALL code, comments, docstrings, CLI output, and docs MUST use canonical terms in prose:
-
-| Banned                   | Canonical              |
-| ------------------------ | ---------------------- |
-| contract / contracts     | rule / rules           |
-| denied                   | blocked                |
-| finding / findings       | violation / violations |
-| engine / workflow / flow | pipeline               |
-| shadow mode              | observe mode           |
-| function call / action   | tool call              |
-| contract bundle          | ruleset                |
-
-**No exceptions in prose.**
-
-For code identifiers, use the actual exported symbol names from the repo.
+When you refer to code, use the real exported identifier names from the repo.
 
 ## API Design Checklist
 
-Before adding any new public API:
+Before adding a public API:
 
-- **Every accepted parameter has an observable effect.** If unimplemented, throw — never silently ignore.
-- **Collection parameters have documented merge semantics.** Document whether it EXTENDS or REPLACES defaults.
-- **Block decisions propagate end-to-end.** Trace block through every adapter. Never return "allow" after a blocked decision.
-- **Callbacks fire exactly once.** Assert `callback.call_count === 1` in tests.
-- **All adapters handle the new feature.** Run adapter parity tests after any change.
+- Every accepted parameter must have an observable effect
+- Document collection merge semantics
+- Block decisions must propagate through every adapter path
+- Callbacks must fire exactly once
+- Shared behavior changes must be covered in adapter parity tests
 
-## Security Review Checklist
+## Review Checklist
 
-Before merging ANY code that touches these areas:
+Before merging changes that touch boundary behavior:
 
-- **Path handling**: Uses `fs.realpathSync()` not just `path.normalize()`. Test with symlinks.
-- **Shell command classification**: All shell metacharacters enumerated. Test with: `\n`, `\r`, `|`, `;`, `&&`, `||`, `$()`, `` ` ``, `${}`, `<()`, `<<`, `>`, `>>`
-- **Error handling in backends**: `get()` and `increment()` fail-closed. Network errors propagate, only 404/missing returns null.
-- **Audit action accuracy**: Audit events reflect what actually happened. Timeouts emit TIMEOUT, not GRANTED.
-- **Input validation**: tool_name, session_id, any string used in storage keys validated for control characters.
-- **Regex DoS**: All regex input capped at 10,000 characters.
-- **Deep freeze**: Any frozen object with nested properties must use deep freeze, not just `Object.freeze()`.
+- Path handling must use real-path aware logic where needed
+- Shell command classification must cover metacharacters and edge cases
+- Backend errors must stay fail-closed
+- Decision-log action values must match what actually happened
+- Storage keys and identifiers must reject control characters
+- Regex inputs must stay size-limited
+- Deep freeze must be used for nested immutable objects
 
 ## Behavior Test Requirement
 
-Every public API parameter MUST have a behavior test.
+Every public API parameter needs a behavior test:
 
-A behavior test answers: "What observable effect does this parameter have?"
+- The test goes through the public API
+- The test proves a real behavioral difference
+- Core behavior tests live in `packages/core/tests/behavior/`
 
-- Tests the parameter's effect through the public API
-- Asserts a concrete difference between passing and not passing the parameter
-- Lives in `packages/core/tests/behavior/`
-- Keep test files focused: one file per module, under 200 lines
+## Boundary Test Requirement
 
-## Negative Security Test Requirement
+Every boundary needs bypass tests. Examples:
 
-Every security boundary MUST have bypass tests — tests that attempt to circumvent the boundary and verify the attempt is caught. Marked with `test.describe("security")` or equivalent.
+- Sandbox path escape attempts
+- Bash metacharacter coverage
+- Session-limit edge cases
+- Identifier validation with null bytes and control characters
 
-Examples:
-
-- Sandbox: symlink escape, double-encoding, null byte injection
-- BashClassifier: every shell metacharacter individually
-- Session limits: concurrent access patterns
-- Input validation: null bytes, control characters, path separators in tool_name
-
-## Feature Parity Matrix
-
-147 features across 12 categories must pass in both Python and TypeScript. See memory file `project_parity_matrix_detail.md` for the full matrix with test IDs.
-
-Cross-language validation: shared YAML rulesets + JSON input/output fixtures. Same input → same output → parity proven.
-
-## Bug & Issue Triage Rule
-
-When working in the project, if a bug, security issue, or problem is detected that was NOT in the initial prompt:
-
-1. Triage — assess severity and whether it blocks current work
-2. If fixable now without derailing the task → fix immediately and mention it
-3. If not fixable now → create a GitHub issue in the repo with proper labels
-4. **Never silently ignore a discovered issue**
-
-## Build & Test
+## Build And Test
 
 ```bash
-pnpm install                           # install all workspace deps
-pnpm -r build                          # build all packages
-pnpm -r test                           # test all packages
-pnpm --filter @edictum/core test       # test core only
-pnpm --filter @edictum/core build      # build core only
+pnpm install
+pnpm -r build
+pnpm -r test
+pnpm --filter @edictum/core test
+pnpm --filter @edictum/core build
 ```
 
 ## Pre-Merge Verification
 
-Every change MUST pass these checks before committing:
-
 ```bash
-pnpm -r build                    # all packages build
-pnpm -r test                     # full test suite
-pnpm -r lint                     # eslint
-pnpm -r typecheck                # tsc --noEmit
-# If touching adapters:
+pnpm -r build
+pnpm -r test
+pnpm -r lint
+pnpm -r typecheck
 pnpm --filter @edictum/core test -- --grep "adapter parity"
 ```
 
-## YAML Schema
+## YAML Shapes
 
-The ruleset schema lives in the `edictum-schemas` repo — single source of truth. Both this repo and the Python repo consume it as a dependency.
+The schema lives in `edictum-schemas`.
 
 - `apiVersion: edictum/v1`, `kind: Ruleset`
-- Rule types: `type: pre` (`action: block` / `action: ask`), `type: post` (`action: warn` / `action: redact` / `action: block`), `type: session` (`action: block` only), `type: sandbox` (allowlist-based)
-- Conditions: `when:` with boolean AST (`all/any/not`) and leaves (`selector: {operator: value}`)
-- 15 operators: exists, equals, not_equals, in, not_in, contains, contains_any, starts_with, ends_with, matches, matches_any, gt, gte, lt, lte
-- Missing fields evaluate to `false`. Type mismatches yield block/warn + `policyError: true`
-- `apiVersion: edictum/v1`, `kind: Workflow` — multi-stage gate definition with `stages`, `entry`/`exit` gates, `tools`, `checks`, and optional `approval` per stage
+- Rule types: `pre`, `post`, `session`, `sandbox`
+- Actions: `block`, `ask`, `warn`, `redact`
+- Conditions live under `when:`
+- `kind: Workflow` uses `stages`, `entry`, `exit`, `checks`, `tools`, and optional `approval`
+- Use `exec(...)` conditions only when `WorkflowRuntime` is created with `execEvaluatorEnabled: true`
 
 ## Ecosystem Context
 
-Edictum is four repos that work together:
-
-- **edictum** (core Python): `edictum-ai/edictum` — MIT Python library. PyPI: `edictum`.
-- **edictum-ts** (core TypeScript): THIS REPO — MIT TypeScript library. npm: `@edictum/core`.
-- **edictum-console** (server): `edictum-ai/edictum-console` — Self-hostable FastAPI + React SPA.
-- **edictum-schemas** (shared): `edictum-ai/edictum-schemas` — Shared YAML ruleset schema.
-
-Both core libraries (Python and TS) work standalone. Console is an optional enhancement. Schema repo is the single source of truth for the ruleset format.
+- `edictum`: Python SDK
+- `edictum-ts`: this repo
+- `edictum-go`: Go SDK
+- `edictum-openclaw`: OpenClaw adapter
+- `edictum-console`: self-hosted dashboard
+- `edictum-schemas`: shared YAML schema
 
 ## Cross-SDK Conformance Workflow
 
-When a change affects shared semantics, YAML validation, fixture behavior, audit/envelope wire format, or policy evaluation behavior, you MUST follow this workflow before merging:
+When a change affects shared semantics, YAML validation, fixture behavior, wire format, or policy evaluation:
 
-1. **Update shared fixtures** in `edictum-schemas` — add or modify `fixtures/rejection/*.rejection.yaml` files as needed
-2. **Update canonical Python behavior** in `edictum` if the change originates there
-3. **Ensure all three SDKs pass** — Python (`edictum`), Go (`edictum-go`), and TypeScript (this repo) shared-fixture runners must all pass with `EDICTUM_CONFORMANCE_REQUIRED=1`
-4. **Do not merge** parity-affecting behavior without the Parity Check workflow passing in all affected repos
+1. Update shared fixtures in `edictum-schemas`
+2. Update canonical Python behavior in `edictum` if needed
+3. Ensure Python, Go, and TypeScript shared-fixture runners all pass with `EDICTUM_CONFORMANCE_REQUIRED=1`
+4. Do not merge parity-affecting behavior until the parity workflow passes
 
-The conformance runner in this repo lives at `packages/core/tests/yaml-engine/shared-fixtures.test.ts` and is executed in CI by:
-
-```bash
-EDICTUM_SCHEMAS_DIR=edictum-schemas EDICTUM_CONFORMANCE_REQUIRED=1 \
-  pnpm --filter @edictum/core test -- --grep "shared rejection fixtures"
-```
-
-The `Parity Check` workflow (`.github/workflows/parity-check.yml`) runs on PRs to main, pushes to main, and weekly. It is intended to be a required status check.
+The TypeScript conformance runner lives at `packages/core/tests/yaml-engine/shared-fixtures.test.ts`.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,37 @@
-# Edictum
+# Edictum TypeScript
 
 [![npm](https://img.shields.io/npm/v/@edictum/core?cacheSeconds=3600)](https://www.npmjs.com/package/@edictum/core)
 [![License](https://img.shields.io/npm/l/@edictum/core?cacheSeconds=86400)](LICENSE)
 [![Node](https://img.shields.io/node/v/@edictum/core?cacheSeconds=86400)](https://www.npmjs.com/package/@edictum/core)
 [![CI](https://github.com/edictum-ai/edictum-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/edictum-ai/edictum-ts/actions/workflows/ci.yml)
 
-TypeScript SDK for runtime rule enforcement on AI agent tool calls.
+> Your agents, your rules.
+>
+> Same YAML rules across Vercel AI, LangChain.js, OpenAI Agents SDK, Claude Agent SDK, and OpenClaw.
 
-Prompts are suggestions. Rules are enforcement.
-The LLM cannot talk its way past a rule.
+Edictum is the TypeScript SDK for a developer agent behavior platform. Write rules and workflows in YAML. Enforce them at the tool-call boundary, not in the prompt.
 
-**55us overhead** · **18 adapters across Python, TypeScript, Go** · **One runtime dep** ([js-yaml](https://github.com/nodeca/js-yaml)) · **Fail-closed by default**
+**Workflow Gates** · **Rules engine** · **5 TypeScript adapters** · **18 adapters across TypeScript, Python, and Go**
 
-```bash
-pnpm add @edictum/core
-```
+## The Problem
+
+`CLAUDE.md` is advisory. It can tell an agent to read the spec, run tests, or avoid production. It cannot stop the next tool call.
+
+The [GAP paper](https://arxiv.org/abs/2602.16943) measured 17,420 datapoints across 6 frontier models and found a 55-79% gap between text refusal and tool-call execution. The model says no in chat, then does the thing anyway.
+
+Most guardrails focus on what the model says. Edictum enforces what the agent does.
 
 ## Quick Start
 
-```typescript
-import { readFile } from 'node:fs/promises'
-import { Edictum, EdictumDenied } from '@edictum/core'
+### 1. Install
 
-const guard = Edictum.fromYaml('rules.yaml')
-
-// toolCallable receives args as Record<string, unknown>
-const governedReadFile = (args: Record<string, unknown>) => readFile(args.path as string, 'utf8')
-
-try {
-  await guard.run('readFile', { path: '.env' }, governedReadFile)
-} catch (e) {
-  if (e instanceof EdictumDenied) console.log(e.reason)
-  // => "Sensitive file '.env' blocked."
-}
+```bash
+pnpm add @edictum/core @edictum/vercel-ai
 ```
 
-**The ruleset** — `rules.yaml`:
+Swap `@edictum/vercel-ai` for `@edictum/langchain`, `@edictum/openai-agents`, or `@edictum/claude-sdk`.
+
+### 2. Write a ruleset
 
 ```yaml
 apiVersion: edictum/v1
@@ -50,165 +46,132 @@ rules:
     tool: readFile
     when:
       args.path:
-        contains_any: ['.env', '.secret', 'credentials', '.pem', 'id_rsa']
+        contains_any: ['.env', '.pem', 'id_rsa', 'credentials']
     then:
       action: block
-      message: "Sensitive file '{args.path}' blocked."
+      message: 'Blocked sensitive file read: {args.path}'
 ```
 
-Rules are YAML. Enforcement is deterministic — no LLM in the evaluation path. The agent cannot bypass a matched rule. Errors, type mismatches, and missing fields all fail closed.
-
-## Packages
-
-| Package                                            | Description                                                              |
-| -------------------------------------------------- | ------------------------------------------------------------------------ |
-| [`@edictum/core`](packages/core)                   | Pipeline, rules, audit, session, YAML engine. One runtime dep (js-yaml). |
-| [`@edictum/vercel-ai`](packages/vercel-ai)         | Vercel AI SDK adapter                                                    |
-| [`@edictum/openai-agents`](packages/openai-agents) | OpenAI Agents SDK adapter                                                |
-| [`@edictum/claude-sdk`](packages/claude-sdk)       | Claude Agent SDK adapter                                                 |
-| [`@edictum/langchain`](packages/langchain)         | LangChain.js adapter                                                     |
-| [`@edictum/server`](packages/server)               | Server SDK — HTTP client, SSE hot-reload, audit sink                     |
-| [`@edictum/otel`](packages/otel)                   | OpenTelemetry spans and metrics                                          |
-
-## Works With Your Framework
-
-**Vercel AI SDK** — callbacks for generateText / streamText:
+### 3. Wrap the SDK you already use
 
 ```typescript
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+import { Edictum } from '@edictum/core'
 import { VercelAIAdapter } from '@edictum/vercel-ai'
+
+const guard = Edictum.fromYaml('rules.yaml')
 const adapter = new VercelAIAdapter(guard)
-const result = await generateText({ ...options, ...adapter.asCallbacks() })
-```
 
-**OpenAI Agents SDK** — input/output guardrails:
-
-```typescript
-import { OpenAIAgentsAdapter } from '@edictum/openai-agents'
-const adapter = new OpenAIAgentsAdapter(guard)
-const { inputGuardrail, outputGuardrail } = adapter.asGuardrails()
-```
-
-**Claude Agent SDK** — pre/post tool use hooks:
-
-```typescript
-import { ClaudeAgentSDKAdapter } from '@edictum/claude-sdk'
-const adapter = new ClaudeAgentSDKAdapter(guard)
-const { PreToolUse, PostToolUse } = adapter.toSdkHooks()
-```
-
-**LangChain.js** — middleware for ToolNode:
-
-```typescript
-import { LangChainAdapter } from '@edictum/langchain'
-const adapter = new LangChainAdapter(guard)
-const middleware = adapter.asMiddleware()
-```
-
-**OpenClaw** — see the OpenClaw adapter repository:
-
-```bash
-openclaw plugins install @edictum/openclaw
-# Zero config — ships with bundled rules
-```
-
-Adapters are thin wrappers. All rule enforcement logic lives in the pipeline.
-
-> **Output-check enforcement:** `guard.run()` guarantees full output-check enforcement. Native adapter hooks enforce preconditions deterministically; redact behavior after execution depends on SDK support. See adapter docs for per-SDK details.
-
-**Multi-stage gates** — stateful gate evaluation and approvals are available in core:
-
-```typescript
-import { Edictum, WorkflowRuntime, loadWorkflowString } from '@edictum/core'
-
-const workflowRuntime = new WorkflowRuntime(
-  loadWorkflowString(`
-apiVersion: edictum/v1
-kind: Workflow
-metadata:
-  name: my-workflow
-stages:
-  - id: read-context
-    tools: [Read]
-`),
-)
-
-const guard = new Edictum({ workflowRuntime })
-```
-
-## What You Can Do
-
-**Rules** — four types covering the full tool call lifecycle:
-
-- **Preconditions** block dangerous calls before execution
-- **Postconditions** scan tool output — warn, redact PII, or block
-- **Session rules** cap total calls, per-tool calls, and retry attempts
-- **Sandbox rules** allowlist file paths, commands, and domains
-
-**Programmatic rules:**
-
-```typescript
-import { Decision, Edictum } from '@edictum/core'
-import type { Precondition } from '@edictum/core'
-
-const noRm: Precondition = {
-  tool: 'Bash',
-  check: async (toolCall) => {
-    if (toolCall.bashCommand?.includes('rm -rf')) return Decision.fail('Cannot run rm -rf')
-    return Decision.pass_()
-  },
-}
-
-const guard = new Edictum({ rules: [noRm] })
-```
-
-**Principal-aware enforcement** — role-gate tools with claims and `env.*` context.
-
-**Callbacks** — `onDeny` / `onAllow` for logging and observability. For human-in-the-loop approvals, use `approvalBackend`.
-
-**Observe mode** — log what would be blocked without blocking, then switch to enforce.
-
-## Edictum Console
-
-Optional self-hostable operations console. Ruleset management, live hot-reload via SSE, human-in-the-loop approvals, audit event feeds, and fleet monitoring.
-
-```typescript
-import { createServerGuard } from '@edictum/server'
-
-const { guard, close } = await createServerGuard({
-  baseUrl: 'http://localhost:8000',
-  apiKey: 'edk_production_...',
-  agentId: 'my-agent',
+await generateText({
+  model: openai('gpt-4.1'),
+  tools: { readFile },
+  ...adapter.asCallbacks(),
 })
 ```
 
-See [edictum-console](https://github.com/edictum-ai/edictum-console) for deployment.
+Same ruleset, different adapter surface:
+
+| SDK               | Adapter call                                    |
+| ----------------- | ----------------------------------------------- |
+| Vercel AI SDK     | `new VercelAIAdapter(guard).asCallbacks()`      |
+| LangChain.js      | `new LangChainAdapter(guard).asMiddleware()`    |
+| OpenAI Agents SDK | `new OpenAIAgentsAdapter(guard).asGuardrails()` |
+| Claude Agent SDK  | `new ClaudeAgentSDKAdapter(guard).toSdkHooks()` |
+
+## Workflow Gates
+
+Workflow Gates are stateful process enforcement. They know which stage a session is in, which files were already read, which commands ran, and whether approval happened.
+
+```yaml
+apiVersion: edictum/v1
+kind: Workflow
+metadata:
+  name: repo-change
+  description: 'Read context, implement, verify'
+  version: '1.0'
+
+stages:
+  - id: read-brief
+    description: 'Read the ticket and repo context'
+    tools: [Read]
+    exit:
+      - condition: file_read("specs/feature.md")
+        message: 'Read the spec first'
+
+  - id: implement
+    description: 'Make the change'
+    tools: [Read, Write, Bash]
+    entry:
+      - condition: stage_complete("read-brief")
+    exit:
+      - condition: exec("pnpm test", exit_code=0)
+        message: 'Tests must pass'
+
+  - id: review
+    description: 'Pause for approval'
+    entry:
+      - condition: stage_complete("implement")
+    approval:
+      message: 'Human approval required before release'
+```
+
+```typescript
+import { readFile } from 'node:fs/promises'
+import { Edictum, WorkflowRuntime, loadWorkflowString } from '@edictum/core'
+
+const workflow = loadWorkflowString(await readFile('workflow.yaml', 'utf8'))
+const workflowRuntime = new WorkflowRuntime(workflow, {
+  execEvaluatorEnabled: true,
+})
+
+const guard = Edictum.fromYaml('rules.yaml', { workflowRuntime })
+```
+
+If you use `exec(...)` in workflow gates, enable the exec evaluator when you create the runtime.
+
+## Rules Engine
+
+Rulesets are deterministic YAML. No model sits in the evaluation path. Use `action: block` to stop a tool call, `action: ask` to pause for approval, `action: warn` to flag output, and `action: redact` to rewrite sensitive output before it leaves the tool boundary.
+
+Core also supports session rules, sandbox rules, principal-aware enforcement, observe mode, and structured decision logs.
+
+## Packages
+
+| Package                                            | Version | Role                                                            |
+| -------------------------------------------------- | ------- | --------------------------------------------------------------- |
+| [`@edictum/core`](packages/core)                   | `0.3.2` | Rules engine, workflow runtime, approvals, decision log helpers |
+| [`@edictum/server`](packages/server)               | `0.3.1` | Server-backed rulesets, sessions, approvals, SSE hot-reload     |
+| [`@edictum/vercel-ai`](packages/vercel-ai)         | `0.2.0` | Vercel AI SDK adapter                                           |
+| [`@edictum/claude-sdk`](packages/claude-sdk)       | `0.2.0` | Claude Agent SDK adapter                                        |
+| [`@edictum/langchain`](packages/langchain)         | `0.2.0` | LangChain.js adapter                                            |
+| [`@edictum/openai-agents`](packages/openai-agents) | `0.2.0` | OpenAI Agents SDK adapter                                       |
+| [`@edictum/otel`](packages/otel)                   | `0.2.0` | OpenTelemetry integration                                       |
+
+TypeScript has five framework adapters total: the four adapters in this monorepo plus OpenClaw in [edictum-openclaw](https://github.com/edictum-ai/edictum-openclaw). `@edictum/core`, `@edictum/server`, and `@edictum/otel` are infrastructure packages, not adapters.
+
+## How It Works
+
+Edictum normalizes each tool call, evaluates rules and workflow gates, applies approvals when needed, and emits a structured decision log. The enforcement path is deterministic, model-agnostic, and fail-closed on invalid input or evaluation errors.
 
 ## Research
 
-Edictum was evaluated across six regulated domains in the GAP benchmark.
-
-[Paper](https://arxiv.org/abs/2602.16943) — [Benchmark](https://github.com/edictum-ai/gap-benchmark)
-
-## Security
-
-This is a security product. See [SECURITY.md](SECURITY.md) for vulnerability reporting.
-
-Every security boundary has bypass tests. Every error path fails closed. Every input used in storage keys is validated.
+Edictum is built against the [GAP benchmark](https://github.com/edictum-ai/gap-benchmark) and the [paper](https://arxiv.org/abs/2602.16943) behind it.
 
 ## Ecosystem
 
-| Repo                                                             | Language       | Role                                       |
-| ---------------------------------------------------------------- | -------------- | ------------------------------------------ |
-| [edictum](https://github.com/edictum-ai/edictum)                 | Python         | Reference implementation (PyPI: `edictum`) |
-| [edictum-ts](https://github.com/edictum-ai/edictum-ts)           | TypeScript     | This repo                                  |
-| [edictum-go](https://github.com/edictum-ai/edictum-go)           | Go             | Full port + adapters                       |
-| [edictum-console](https://github.com/edictum-ai/edictum-console) | Python + React | Self-hostable ops console                  |
-| [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | YAML           | Shared ruleset schema                      |
-| [edictum-demo](https://github.com/edictum-ai/edictum-demo)       | Python         | Demos, adversarial tests, benchmarks       |
+| Repo                                                               | Language       | Role                  |
+| ------------------------------------------------------------------ | -------------- | --------------------- |
+| [edictum](https://github.com/edictum-ai/edictum)                   | Python         | Python SDK            |
+| [edictum-ts](https://github.com/edictum-ai/edictum-ts)             | TypeScript     | This repo             |
+| [edictum-go](https://github.com/edictum-ai/edictum-go)             | Go             | Go SDK                |
+| [edictum-openclaw](https://github.com/edictum-ai/edictum-openclaw) | TypeScript     | OpenClaw adapter      |
+| [edictum-console](https://github.com/edictum-ai/edictum-console)   | Python + React | Self-hosted dashboard |
+| [edictum-schemas](https://github.com/edictum-ai/edictum-schemas)   | YAML           | Shared ruleset schema |
 
 - [Documentation](https://docs.edictum.ai)
 - [Website](https://edictum.ai)
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -1,8 +1,8 @@
 # @edictum/claude-sdk
 
-Claude Agent SDK adapter for Edictum rule enforcement.
+Version `0.2.0`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Claude Agent SDK adapter for Edictum. Keep Claude's hook surface and enforce the same YAML ruleset you use in the rest of the stack.
 
 ## Install
 
@@ -17,17 +17,25 @@ import { Edictum } from '@edictum/core'
 import { ClaudeAgentSDKAdapter } from '@edictum/claude-sdk'
 
 const guard = Edictum.fromYaml('rules.yaml')
-const adapter = new ClaudeAgentSDKAdapter(guard)
+const adapter = new ClaudeAgentSDKAdapter(guard, {
+  sessionId: 'run-42',
+  parentSessionId: 'agent-root',
+})
+
 const { PreToolUse, PostToolUse } = adapter.toSdkHooks()
 ```
 
-## API
+## Notes
 
-- `ClaudeAgentSDKAdapter` — adapter class
-  - `toSdkHooks(options?)` — returns `{ PreToolUse, PostToolUse }` hook callback arrays
-  - `setPrincipal(principal)` — update principal mid-session
-- `ClaudeAgentSDKAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
-- `ToSdkHooksOptions` — `{ onPostconditionWarn }` callback
+- `parentSessionId` keeps lineage for nested agent runs
+- Workflow stage context and approval state are emitted when the guard has a `WorkflowRuntime`
+- Post-tool output replacement depends on the Claude Agent SDK honoring `updatedMCPToolOutput`
+
+## Key Exports
+
+- `ClaudeAgentSDKAdapter`
+- `ClaudeAgentSDKAdapterOptions`
+- `ToSdkHooksOptions`
 
 ## Links
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 # @edictum/core
 
-Runtime rule enforcement for AI agent tool calls. One runtime dep ([js-yaml](https://github.com/nodeca/js-yaml)).
+Version `0.3.2`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Rules engine and workflow runtime for Edictum. Write rules and workflows in YAML. Enforce them at the tool-call boundary.
 
 ## Install
 
@@ -10,36 +10,74 @@ Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enf
 pnpm add @edictum/core
 ```
 
-## Usage
+## Run a ruleset
 
 ```typescript
 import { readFile } from 'node:fs/promises'
 import { Edictum, EdictumDenied } from '@edictum/core'
 
 const guard = Edictum.fromYaml('rules.yaml')
-
 const governedReadFile = (args: Record<string, unknown>) => readFile(args.path as string, 'utf8')
 
 try {
   await guard.run('readFile', { path: '.env' }, governedReadFile)
-} catch (e) {
-  if (e instanceof EdictumDenied) console.log(e.reason)
+} catch (error) {
+  if (error instanceof EdictumDenied) {
+    console.log(error.reason)
+  }
 }
 ```
 
+```yaml
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: file-safety
+rules:
+  - id: block-sensitive-reads
+    type: pre
+    tool: readFile
+    when:
+      args.path:
+        contains_any: ['.env', '.pem', 'id_rsa']
+    then:
+      action: block
+      message: 'Blocked sensitive file read: {args.path}'
+```
+
+## Add Workflow Gates
+
+```typescript
+import { readFile } from 'node:fs/promises'
+import { Edictum, WorkflowRuntime, loadWorkflowString } from '@edictum/core'
+
+const workflow = loadWorkflowString(await readFile('workflow.yaml', 'utf8'))
+const workflowRuntime = new WorkflowRuntime(workflow, {
+  execEvaluatorEnabled: true,
+})
+
+const guard = Edictum.fromYaml('rules.yaml', { workflowRuntime })
+```
+
+Workflow Gates use `kind: Workflow` documents with `stages`, `entry`, `exit`, `checks`, and optional `approval`.
+
 ## Key Exports
 
-- `Edictum` — main guard class (`fromYaml`, `fromYamlString`, `run`, `evaluate`)
-- `EdictumDenied`, `EdictumConfigError`, `EdictumToolError` — error types
-- `CheckPipeline` — pipeline implementation used by adapters
-- `Decision` — rule result builder (`pass_()`, `fail(message)`)
-- `Session`, `MemoryBackend` — session tracking and storage
-- `RedactionPolicy` — sensitive field redaction for audit events
-- `CollectingAuditSink`, `StdoutAuditSink`, `FileAuditSink`, `CompositeSink` — audit sinks
-- `createEnvelope`, `ToolCall`, `SideEffect` — tool-call construction and metadata
-- `WorkflowRuntime`, `loadWorkflow`, `loadWorkflowString` — stateful multi-stage gate evaluation and YAML loaders
-- `composeBundles`, `loadBundle`, `compileContracts` — YAML engine helpers
-- `createViolation`, `buildViolations`, `Violation` — output-check violation helpers
+- `Edictum`, `EdictumDenied`, `EdictumConfigError`, `EdictumToolError`
+- `Decision`, `CheckPipeline`, `run`
+- `Session`, `MemoryBackend`, `LocalApprovalBackend`, `RedactionPolicy`
+- `CollectingAuditSink`, `StdoutAuditSink`, `FileAuditSink`, `CompositeSink`
+- `WorkflowRuntime`, `loadWorkflow`, `loadWorkflowString`, `WorkflowAction`
+- Workflow definition types: `WorkflowDefinition`, `WorkflowStage`, `WorkflowGate`, `WorkflowCheck`, `WorkflowApproval`, `WorkflowRuntimeOptions`
+- Workflow state types: `WorkflowContext`, `WorkflowEvaluation`, `WorkflowState`, `WorkflowPendingApproval`, `WorkflowRecordedEvidence`, `WorkflowBlockedAction`
+- YAML engine helpers: `fromYaml`, `fromYamlString`, `reload`, `loadBundle`, `loadBundleString`, `composeBundles`
+
+## What Core Includes
+
+- Deterministic ruleset evaluation with pre, post, session, and sandbox rules
+- Workflow Gates with stage state, approvals, and recorded evidence
+- Decision log helpers and redaction support
+- Framework-agnostic tool wrapping through `guard.run()` and `run()`
 
 ## Links
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -1,8 +1,8 @@
 # @edictum/langchain
 
-LangChain.js adapter for Edictum rule enforcement.
+Version `0.2.0`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+LangChain.js adapter for Edictum. Keep your LangChain tool graph and add deterministic rule enforcement around tool calls.
 
 ## Install
 
@@ -17,19 +17,28 @@ import { Edictum } from '@edictum/core'
 import { LangChainAdapter } from '@edictum/langchain'
 
 const guard = Edictum.fromYaml('rules.yaml')
-const adapter = new LangChainAdapter(guard)
+const adapter = new LangChainAdapter(guard, {
+  sessionId: 'run-42',
+  parentSessionId: 'agent-root',
+})
+
 const middleware = adapter.asMiddleware()
 // Pass to ToolNode or agent as tool_call_middleware
 ```
 
-## API
+## What It Exposes
 
-- `LangChainAdapter` — adapter class
-  - `asMiddleware(options?)` — returns `{ name, wrapToolCall }` for ToolNode
-  - `asToolWrapper(options?)` — returns a wrapper function for any tool callable
-  - `setPrincipal(principal)` — update principal mid-session
-- `LangChainAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
-- `AsMiddlewareOptions` — `{ onPostconditionWarn }` callback
+- `asMiddleware()` for ToolNode and LangChain middleware paths
+- `asToolWrapper()` for wrapping arbitrary tool callables directly
+- `parentSessionId` support for nested-agent lineage
+- Workflow-aware events when the guard includes a `WorkflowRuntime`
+
+## Key Exports
+
+- `LangChainAdapter`
+- `LangChainAdapterOptions`
+- `AsMiddlewareOptions`
+- `AsToolWrapperOptions`
 
 ## Links
 

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -1,8 +1,8 @@
 # @edictum/openai-agents
 
-OpenAI Agents SDK adapter for Edictum rule enforcement.
+Version `0.2.0`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+OpenAI Agents SDK adapter for Edictum. Use native input and output guardrails while keeping the same YAML ruleset you use in other SDKs.
 
 ## Install
 
@@ -17,17 +17,25 @@ import { Edictum } from '@edictum/core'
 import { OpenAIAgentsAdapter } from '@edictum/openai-agents'
 
 const guard = Edictum.fromYaml('rules.yaml')
-const adapter = new OpenAIAgentsAdapter(guard)
+const adapter = new OpenAIAgentsAdapter(guard, {
+  sessionId: 'run-42',
+  parentSessionId: 'agent-root',
+})
+
 const { inputGuardrail, outputGuardrail } = adapter.asGuardrails()
 ```
 
-## API
+## Notes
 
-- `OpenAIAgentsAdapter` — adapter class
-  - `asGuardrails(options?)` — returns `{ inputGuardrail, outputGuardrail }`
-  - `setPrincipal(principal)` — update principal mid-session
-- `OpenAIAgentsAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
-- `AsGuardrailsOptions` — `{ onPostconditionWarn }` callback
+- `parentSessionId` preserves lineage in emitted decision-log events
+- Workflow context is included automatically when the guard has a `WorkflowRuntime`
+- Native output guardrails can tripwire blocked output, but they do not rewrite tool results
+
+## Key Exports
+
+- `OpenAIAgentsAdapter`
+- `OpenAIAgentsAdapterOptions`
+- `AsGuardrailsOptions`
 
 ## Links
 

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -1,8 +1,8 @@
 # @edictum/otel
 
-OpenTelemetry integration for Edictum rule enforcement.
+Version `0.2.0`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+OpenTelemetry integration for Edictum spans and metrics.
 
 ## Install
 
@@ -13,30 +13,26 @@ pnpm add @edictum/otel @edictum/core @opentelemetry/api
 ## Usage
 
 ```typescript
-import { GovernanceTelemetry } from '@edictum/otel'
-
-const telemetry = new GovernanceTelemetry()
-const span = telemetry.startToolSpan(envelope)
-// ... run pipeline ...
-telemetry.setSpanOk(span) // or setSpanError(span, reason)
-```
-
-For automatic no-op fallback when OTel isn't installed:
-
-```typescript
 import { createTelemetry } from '@edictum/otel'
 
 const telemetry = await createTelemetry()
-// Returns GovernanceTelemetry if @opentelemetry/api is available, NoOpTelemetry otherwise
+const span = telemetry.startToolSpan(envelope)
+// ... run the guard or adapter ...
+telemetry.setSpanOk(span)
 ```
 
-## API
+## What It Adds
 
-- `GovernanceTelemetry` — emits rule-enforcement spans and counters (requires `@opentelemetry/api`)
-- `NoOpTelemetry`, `NoOpSpan` — no-op fallback when OTel isn't installed
-- `createTelemetry()` — async factory with runtime detection
-- `hasOtel()`, `hasOtelAsync()` — check if `@opentelemetry/api` is available
-- `configureOtel(options)` — setup helper for common OTel configurations
+- OTel spans and counters around tool calls and rule evaluation
+- No-op fallback when OTel packages are not installed
+- `configureOtel()` for common exporter setup
+
+## Key Exports
+
+- `createTelemetry`
+- `configureOtel`
+- `hasOtel`
+- `hasOtelAsync`
 
 ## Links
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,8 +1,8 @@
 # @edictum/server
 
-Server SDK for connecting Edictum-governed agents to the Edictum API.
+Version `0.3.1`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Server-backed rulesets, approvals, session storage, and decision-log streaming for Edictum.
 
 ## Install
 
@@ -16,28 +16,37 @@ pnpm add @edictum/server @edictum/core
 import { createServerGuard } from '@edictum/server'
 
 const { guard, close } = await createServerGuard({
-  url: 'https://api.example.com',
+  url: 'https://api.edictum.ai',
   apiKey: 'edk_production_...',
   agentId: 'my-agent',
   bundleName: 'production-rules',
 })
 
 // guard is a standard Edictum instance backed by the API
-// Rules hot-reload via SSE, audit events stream to the API
+// rules hot-reload over SSE
+// approvals and session state come from the server
 
-// Clean up on shutdown
 await close()
 ```
 
-## API
+## What It Adds
 
-- `createServerGuard(options)` — factory returning `{ guard, close }` with server-backed rules, audit, sessions, and approvals
-- `EdictumServerClient` — low-level HTTP client for the canonical `/v1` API
-- `ServerRuleSource` — SSE-based rules hot-reload
-- `ServerAuditSink` — streams audit events to the API
-- `ServerBackend` — server-backed session storage
-- `ServerApprovalBackend` — server-backed HITL approval workflows
-- `verifyBundleSignature(bundle, publicKey)` — Ed25519 bundle signature verification
+- Fetches a named ruleset from the canonical `/v1` API
+- Hot-reloads rulesets over SSE
+- Uses server-backed approvals and session storage
+- Carries workflow context through emitted decision-log events when the attached guard is using Workflow Gates
+- Preserves session lineage when adapters supply `parentSessionId`
+- Supports Ed25519 signature verification for fetched rulesets
+
+## Key Exports
+
+- `createServerGuard`
+- `EdictumServerClient`
+- `ServerRuleSource`
+- `ServerBackend`
+- `ServerApprovalBackend`
+- `ServerAuditSink`
+- `verifyBundleSignature`
 
 ## Links
 

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -1,8 +1,8 @@
 # @edictum/vercel-ai
 
-Vercel AI SDK adapter for Edictum rule enforcement.
+Version `0.2.0`.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Vercel AI SDK adapter for Edictum. Use the same YAML ruleset you use elsewhere and enforce it through `generateText()` or `streamText()`.
 
 ## Install
 
@@ -13,26 +13,35 @@ pnpm add @edictum/vercel-ai @edictum/core
 ## Usage
 
 ```typescript
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
 import { Edictum } from '@edictum/core'
 import { VercelAIAdapter } from '@edictum/vercel-ai'
 
 const guard = Edictum.fromYaml('rules.yaml')
-const adapter = new VercelAIAdapter(guard)
+const adapter = new VercelAIAdapter(guard, {
+  sessionId: 'run-42',
+  parentSessionId: 'agent-root',
+})
 
-const result = await generateText({
-  model: openai('gpt-4o'),
+await generateText({
+  model: openai('gpt-4.1'),
   tools: { myTool },
   ...adapter.asCallbacks(),
 })
 ```
 
-## API
+## Workflow And Lineage
 
-- `VercelAIAdapter` — adapter class
-  - `asCallbacks(options?)` — returns `{ experimental_onToolCallStart, experimental_onToolCallFinish }`
-  - `setPrincipal(principal)` — update principal mid-session
-- `VercelAIAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
-- `AsCallbacksOptions` — `{ onPostconditionWarn }` callback
+- `parentSessionId` keeps lineage when one agent run starts another
+- If the guard has a `WorkflowRuntime`, the adapter emits workflow stage context and approval state automatically
+- The adapter surface is `asCallbacks()`, which returns `experimental_onToolCallStart` and `experimental_onToolCallFinish`
+
+## Key Exports
+
+- `VercelAIAdapter`
+- `VercelAIAdapterOptions`
+- `AsCallbacksOptions`
 
 ## Links
 


### PR DESCRIPTION
## Summary
- rewrite the TypeScript README and package docs around the current rules and workflow gate framing
- add changelog entries for the server and vercel-ai packages plus align package metadata copy
- update peer dependency ranges for the non-core packages to match the 0.4.0 line

## Verification
- pre-commit build, lint, and format checks passed
- this branch is stacked on top of #164
