### PR TITLE
docs: refresh ecosystem references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,15 +29,15 @@ packages/
 
 ## Tech Stack
 
-| Layer           | Technology          | Rationale                                                      |
-| --------------- | ------------------- | -------------------------------------------------------------- |
-| Language        | TypeScript (strict) | Security product — type safety is non-negotiable               |
-| Runtime         | Node 22+ (LTS)      | Native fetch/structuredClone and current package support        |
-| Build           | tsup (esbuild)      | Dual ESM+CJS output, ~10 lines config                          |
-| Test            | Vitest              | ESM-native, fast, good DX                                      |
-| Lint            | ESLint              | Largest plugin ecosystem, best for security rules              |
-| Package manager | pnpm                | Workspace monorepo support                                     |
-| Module format   | Dual ESM + CJS      | Maximum compatibility via tsup                                 |
+| Layer           | Technology          | Rationale                                                |
+| --------------- | ------------------- | -------------------------------------------------------- |
+| Language        | TypeScript (strict) | Security product — type safety is non-negotiable         |
+| Runtime         | Node 22+ (LTS)      | Native fetch/structuredClone and current package support |
+| Build           | tsup (esbuild)      | Dual ESM+CJS output, ~10 lines config                    |
+| Test            | Vitest              | ESM-native, fast, good DX                                |
+| Lint            | ESLint              | Largest plugin ecosystem, best for security rules        |
+| Package manager | pnpm                | Workspace monorepo support                               |
+| Module format   | Dual ESM + CJS      | Maximum compatibility via tsup                           |
 
 ## Non-Negotiable Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 ## What is Edictum
 
-Runtime rule enforcement for AI agent tool calls. Deterministic pipeline: checks before execution, output checks after execution, session rules, principal-aware enforcement. Framework adapters (Vercel AI SDK, OpenAI Agents SDK, OpenClaw, Claude Agent SDK, LangChain.js). One runtime dep in core (js-yaml). Full feature parity with the Python library (`edictum` on PyPI, v0.15.0).
+Runtime rule enforcement for AI agent tool calls. Deterministic pipeline: checks before execution, output checks after execution, session rules, principal-aware enforcement. Framework adapters (Vercel AI SDK, OpenAI Agents SDK, Claude Agent SDK, LangChain.js). One runtime dep in core (js-yaml). Full feature parity with the Python library.
 
-Current version: 0.3.0 (npm: `@edictum/core`)
+Current version: 0.4.2 (npm: `@edictum/core`)
 
 ## THE ONE RULE
 
@@ -21,9 +21,9 @@ packages/
 ├── core/              # @edictum/core — pipeline, rules, audit, session, YAML engine
 ├── vercel-ai/         # @edictum/vercel-ai — Vercel AI SDK adapter
 ├── openai-agents/     # @edictum/openai-agents — OpenAI Agents SDK adapter
-├── openclaw/          # @edictum/openclaw — OpenClaw adapter
 ├── claude-sdk/        # @edictum/claude-sdk — Claude Agent SDK adapter
 ├── langchain/         # @edictum/langchain — LangChain.js adapter
+├── otel/              # @edictum/otel — OpenTelemetry integration
 └── server/            # @edictum/server — Server SDK (HTTP client, SSE, audit sink)
 ```
 
@@ -32,7 +32,7 @@ packages/
 | Layer           | Technology          | Rationale                                                      |
 | --------------- | ------------------- | -------------------------------------------------------------- |
 | Language        | TypeScript (strict) | Security product — type safety is non-negotiable               |
-| Runtime         | Node 22+ (LTS)      | Required by OpenClaw (P0 target), native fetch/structuredClone |
+| Runtime         | Node 22+ (LTS)      | Native fetch/structuredClone and current package support        |
 | Build           | tsup (esbuild)      | Dual ESM+CJS output, ~10 lines config                          |
 | Test            | Vitest              | ESM-native, fast, good DX                                      |
 | Lint            | ESLint              | Largest plugin ecosystem, best for security rules              |
@@ -206,14 +206,16 @@ The ruleset schema lives in the `edictum-schemas` repo — single source of trut
 
 ## Ecosystem Context
 
-Edictum is four repos that work together:
+Edictum spans multiple repos that work together:
 
 - **edictum** (core Python): `edictum-ai/edictum` — MIT Python library. PyPI: `edictum`.
 - **edictum-ts** (core TypeScript): THIS REPO — MIT TypeScript library. npm: `@edictum/core`.
-- **edictum-console** (server): `edictum-ai/edictum-console` — Self-hostable FastAPI + React SPA.
-- **edictum-schemas** (shared): `edictum-ai/edictum-schemas` — Shared YAML ruleset schema.
+- **edictum-go** (core Go): `edictum-ai/edictum-go` — Go SDK and CLI.
+- **edictum-api** (control-plane API): `edictum-ai/edictum-api` — hosted backend for runs, approvals, notifications, and audit.
+- **edictum-app** (control-plane UI): `edictum-ai/edictum-app` — hosted frontend for runs, approvals, policies, and settings.
+- **edictum-schemas** (shared): `edictum-ai/edictum-schemas` — Shared schema and conformance fixtures.
 
-Both core libraries (Python and TS) work standalone. Console is an optional enhancement. Schema repo is the single source of truth for the ruleset format.
+The SDKs work standalone. The control plane is optional. The schema repo is the single source of truth for shared formats and fixtures.
 
 ## Cross-SDK Conformance Workflow
 

--- a/README.md
+++ b/README.md
@@ -190,15 +190,15 @@ Every security boundary has bypass tests. Every error path fails closed. Every i
 
 ## Ecosystem
 
-| Repo                                                             | Language       | Role                                       |
-| ---------------------------------------------------------------- | -------------- | ------------------------------------------ |
-| [edictum](https://github.com/edictum-ai/edictum)                 | Python         | Reference implementation (PyPI: `edictum`) |
-| [edictum-ts](https://github.com/edictum-ai/edictum-ts)           | TypeScript     | This repo                                  |
-| [edictum-go](https://github.com/edictum-ai/edictum-go)           | Go             | Full port + adapters                       |
-| [edictum-api](https://github.com/edictum-ai/edictum-api)         | Go             | Hosted control-plane API                   |
-| [edictum-app](https://github.com/edictum-ai/edictum-app)         | React          | Hosted control-plane UI                    |
-| [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | JSON Schema    | Shared ruleset schema                      |
-| [edictum-demo](https://github.com/edictum-ai/edictum-demo)       | Python         | Demos, adversarial tests, benchmarks       |
+| Repo                                                             | Language    | Role                                       |
+| ---------------------------------------------------------------- | ----------- | ------------------------------------------ |
+| [edictum](https://github.com/edictum-ai/edictum)                 | Python      | Reference implementation (PyPI: `edictum`) |
+| [edictum-ts](https://github.com/edictum-ai/edictum-ts)           | TypeScript  | This repo                                  |
+| [edictum-go](https://github.com/edictum-ai/edictum-go)           | Go          | Full port + adapters                       |
+| [edictum-api](https://github.com/edictum-ai/edictum-api)         | Go          | Hosted control-plane API                   |
+| [edictum-app](https://github.com/edictum-ai/edictum-app)         | React       | Hosted control-plane UI                    |
+| [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | JSON Schema | Shared ruleset schema                      |
+| [edictum-demo](https://github.com/edictum-ai/edictum-demo)       | Python      | Demos, adversarial tests, benchmarks       |
 
 - [Documentation](https://docs.edictum.ai)
 - [Website](https://edictum.ai)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TypeScript SDK for runtime rule enforcement on AI agent tool calls.
 Prompts are suggestions. Rules are enforcement.
 The LLM cannot talk its way past a rule.
 
-**55us overhead** · **18 adapters across Python, TypeScript, Go** · **One runtime dep** ([js-yaml](https://github.com/nodeca/js-yaml)) · **Fail-closed by default**
+**55us overhead** · **Python, TypeScript, and Go SDKs** · **One runtime dep** ([js-yaml](https://github.com/nodeca/js-yaml)) · **Fail-closed by default**
 
 ```bash
 pnpm add @edictum/core
@@ -104,13 +104,6 @@ const adapter = new LangChainAdapter(guard)
 const middleware = adapter.asMiddleware()
 ```
 
-**OpenClaw** — see the OpenClaw adapter repository:
-
-```bash
-openclaw plugins install @edictum/openclaw
-# Zero config — ships with bundled rules
-```
-
 Adapters are thin wrappers. All rule enforcement logic lives in the pipeline.
 
 > **Output-check enforcement:** `guard.run()` guarantees full output-check enforcement. Native adapter hooks enforce preconditions deterministically; redact behavior after execution depends on SDK support. See adapter docs for per-SDK details.
@@ -181,7 +174,7 @@ const { guard, close } = await createServerGuard({
 })
 ```
 
-See [edictum-console](https://github.com/edictum-ai/edictum-console) for deployment.
+See the [console docs](https://docs.edictum.ai/docs/console) for the current control-plane surface.
 
 ## Research
 
@@ -202,8 +195,9 @@ Every security boundary has bypass tests. Every error path fails closed. Every i
 | [edictum](https://github.com/edictum-ai/edictum)                 | Python         | Reference implementation (PyPI: `edictum`) |
 | [edictum-ts](https://github.com/edictum-ai/edictum-ts)           | TypeScript     | This repo                                  |
 | [edictum-go](https://github.com/edictum-ai/edictum-go)           | Go             | Full port + adapters                       |
-| [edictum-console](https://github.com/edictum-ai/edictum-console) | Python + React | Self-hostable ops console                  |
-| [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | YAML           | Shared ruleset schema                      |
+| [edictum-api](https://github.com/edictum-ai/edictum-api)         | Go             | Hosted control-plane API                   |
+| [edictum-app](https://github.com/edictum-ai/edictum-app)         | React          | Hosted control-plane UI                    |
+| [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | JSON Schema    | Shared ruleset schema                      |
 | [edictum-demo](https://github.com/edictum-ai/edictum-demo)       | Python         | Demos, adversarial tests, benchmarks       |
 
 - [Documentation](https://docs.edictum.ai)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ const { guard, close } = await createServerGuard({
 })
 ```
 
-See the [control-plane docs](https://docs.edictum.ai/docs/console) for the current control-plane surface.
+See the [control-plane docs](https://docs.edictum.ai/docs/control-plane) for the current control-plane surface.
 
 ## Research
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ const guard = new Edictum({ rules: [noRm] })
 
 **Observe mode** — log what would be blocked without blocking, then switch to enforce.
 
-## Edictum Console
+## Edictum Control Plane
 
-Optional self-hostable operations console. Ruleset management, live hot-reload via SSE, human-in-the-loop approvals, audit event feeds, and fleet monitoring.
+Optional hosted control plane. Ruleset management, live hot-reload via SSE, human-in-the-loop approvals, audit event feeds, and fleet monitoring.
 
 ```typescript
 import { createServerGuard } from '@edictum/server'
@@ -174,7 +174,7 @@ const { guard, close } = await createServerGuard({
 })
 ```
 
-See the [console docs](https://docs.edictum.ai/docs/console) for the current control-plane surface.
+See the [control-plane docs](https://docs.edictum.ai/docs/console) for the current control-plane surface.
 
 ## Research
 


### PR DESCRIPTION
## Summary
- remove stale adapter and OpenClaw package claims from the TS docs
- replace dead console repo references with the current control-plane docs
- refresh the ecosystem section to point at the active repos