### PR TITLE
chore: prepare core v0.5.0 release

### DIFF
--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/claude-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude Agent SDK adapter for edictum",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": "^0.3.0",
+    "@edictum/core": ">=0.3.0 <0.6.0",
     "@anthropic-ai/claude-agent-sdk": ">=0.1.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/core",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Runtime rule enforcement for AI agent tool calls",
   "license": "MIT",
   "type": "module",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/langchain",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "LangChain.js adapter for edictum",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": "^0.3.0",
+    "@edictum/core": ">=0.3.0 <0.6.0",
     "langchain": ">=0.3.0"
   },
   "devDependencies": {

--- a/packages/openai-agents/package.json
+++ b/packages/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/openai-agents",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenAI Agents SDK adapter for edictum",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": "^0.3.0",
+    "@edictum/core": ">=0.3.0 <0.6.0",
     "@openai/agents": ">=0.7.0"
   },
   "devDependencies": {

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/otel",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenTelemetry integration for Edictum rule enforcement",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": "^0.3.0",
+    "@edictum/core": ">=0.3.0 <0.6.0",
     "@opentelemetry/api": ">=1.0.0",
     "@opentelemetry/resources": ">=1.0.0",
     "@opentelemetry/sdk-trace-base": ">=1.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Server SDK (HTTP client, SSE, audit sink) for edictum",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": "^0.4.0"
+    "@edictum/core": ">=0.4.0 <0.6.0"
   },
   "devDependencies": {
     "@edictum/core": "workspace:*",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/vercel-ai",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vercel AI SDK adapter for edictum",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": "^0.4.0",
+    "@edictum/core": ">=0.4.0 <0.6.0",
     "ai": ">=5.0.0 <7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- bump `@edictum/core` from `0.4.2` to `0.5.0`
- widen adapter/server peer ranges so the published packages remain installable with the new core line
- patch-bump the dependent packages that need republishing for the peer range update

## Validation
- pnpm lint
- pnpm -r build
- pnpm -r test
