### PR TITLE
docs: align SDK docs with agency control narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 [![Node](https://img.shields.io/node/v/@edictum/core?cacheSeconds=86400)](https://www.npmjs.com/package/@edictum/core)
 [![CI](https://github.com/edictum-ai/edictum-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/edictum-ai/edictum-ts/actions/workflows/ci.yml)
 
-TypeScript SDK for runtime rule enforcement on AI agent tool calls.
+Edictum is the agency control layer for production AI agents in TypeScript.
 
-Prompts are suggestions. Rules are enforcement.
-The LLM cannot talk its way past a rule.
+Agent frameworks build the agent. Edictum bounds the agency.
+
+Edictum turns documented agent profiles into executable runtime boundaries: tools, data operations, workflow stage, required evidence, human approvals, and audit. Rulesets enforce call-level behavior. Workflow Gates enforce ordered process across calls.
 
 **55us overhead** · **Python, TypeScript, and Go SDKs** · **One runtime dep** ([js-yaml](https://github.com/nodeca/js-yaml)) · **Fail-closed by default**
 
@@ -16,7 +17,9 @@ The LLM cannot talk its way past a rule.
 pnpm add @edictum/core
 ```
 
-## Quick Start
+## Single Tool-Call Enforcement
+
+This quickstart blocks one tool call before execution. The same `Edictum` instance can be used directly or through a framework adapter.
 
 ```typescript
 import { readFile } from 'node:fs/promises'
@@ -35,7 +38,7 @@ try {
 }
 ```
 
-**The ruleset** — `rules.yaml`:
+**The single-call ruleset**: `rules.yaml`
 
 ```yaml
 apiVersion: edictum/v1
@@ -58,19 +61,64 @@ rules:
 
 Rules are YAML. Enforcement is deterministic — no LLM in the evaluation path. The agent cannot bypass a matched rule. Errors, type mismatches, and missing fields all fail closed.
 
+## Workflow Gates
+
+Workflow Gates enforce ordered process with runtime state, evidence, approvals, and audit. A ruleset can block a dangerous call; a Workflow Gate can block a call because it is happening in the wrong stage or without the required evidence.
+
+```typescript
+import { Edictum, LocalApprovalBackend, WorkflowRuntime, loadWorkflowString } from '@edictum/core'
+
+const workflowRuntime = new WorkflowRuntime(
+  loadWorkflowString(`
+apiVersion: edictum/v1
+kind: Workflow
+metadata:
+  name: release-process
+stages:
+  - id: read-context
+    tools: [Read]
+    exit:
+      - condition: file_read("specs/release.md")
+        message: Read the release spec first
+  - id: implement
+    entry:
+      - condition: stage_complete("read-context")
+    tools: [Edit]
+  - id: review
+    entry:
+      - condition: stage_complete("implement")
+    approval:
+      message: Approval required before publish
+  - id: publish
+    entry:
+      - condition: stage_complete("review")
+    tools: [Bash]
+`),
+)
+
+const guard = new Edictum({
+  workflowRuntime,
+  approvalBackend: new LocalApprovalBackend(),
+})
+```
+
+The gate stores evidence such as completed stages and file reads, asks for approval at the review boundary, and emits audit records when a call is blocked, approved, or allowed.
+
 ## Packages
 
-| Package                                            | Description                                                              |
-| -------------------------------------------------- | ------------------------------------------------------------------------ |
-| [`@edictum/core`](packages/core)                   | Pipeline, rules, audit, session, YAML engine. One runtime dep (js-yaml). |
-| [`@edictum/vercel-ai`](packages/vercel-ai)         | Vercel AI SDK adapter                                                    |
-| [`@edictum/openai-agents`](packages/openai-agents) | OpenAI Agents SDK adapter                                                |
-| [`@edictum/claude-sdk`](packages/claude-sdk)       | Claude Agent SDK adapter                                                 |
-| [`@edictum/langchain`](packages/langchain)         | LangChain.js adapter                                                     |
-| [`@edictum/server`](packages/server)               | Server SDK — HTTP client, SSE hot-reload, audit sink                     |
-| [`@edictum/otel`](packages/otel)                   | OpenTelemetry spans and metrics                                          |
+| Package                                            | Description                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------------ |
+| [`@edictum/core`](packages/core)                   | Agency-boundary runtime, rulesets, Workflow Gates, audit, sessions |
+| [`@edictum/vercel-ai`](packages/vercel-ai)         | Vercel AI SDK adapter                                              |
+| [`@edictum/openai-agents`](packages/openai-agents) | OpenAI Agents SDK adapter                                          |
+| [`@edictum/claude-sdk`](packages/claude-sdk)       | Claude Agent SDK adapter                                           |
+| [`@edictum/langchain`](packages/langchain)         | LangChain.js adapter                                               |
+| [`@edictum/server`](packages/server)               | Server SDK: HTTP client, SSE hot-reload, approvals, audit sink     |
+| [`@edictum/otel`](packages/otel)                   | OpenTelemetry spans and behavioral conformance metrics             |
 
 ## Works With Your Framework
+
+Edictum composes with Vercel AI SDK, LangChain.js, OpenAI Agents, and Claude SDK. The framework owns planning, model calls, memory, and tool routing. Edictum enforces the declared agency boundaries at runtime.
 
 **Vercel AI SDK** — callbacks for generateText / streamText:
 
@@ -80,7 +128,7 @@ const adapter = new VercelAIAdapter(guard)
 const result = await generateText({ ...options, ...adapter.asCallbacks() })
 ```
 
-**OpenAI Agents SDK** — input/output guardrails:
+**OpenAI Agents SDK** — input/output enforcement hooks:
 
 ```typescript
 import { OpenAIAgentsAdapter } from '@edictum/openai-agents'
@@ -107,26 +155,6 @@ const middleware = adapter.asMiddleware()
 Adapters are thin wrappers. All rule enforcement logic lives in the pipeline.
 
 > **Output-check enforcement:** `guard.run()` guarantees full output-check enforcement. Native adapter hooks enforce preconditions deterministically; redact behavior after execution depends on SDK support. See adapter docs for per-SDK details.
-
-**Multi-stage gates** — stateful gate evaluation and approvals are available in core:
-
-```typescript
-import { Edictum, WorkflowRuntime, loadWorkflowString } from '@edictum/core'
-
-const workflowRuntime = new WorkflowRuntime(
-  loadWorkflowString(`
-apiVersion: edictum/v1
-kind: Workflow
-metadata:
-  name: my-workflow
-stages:
-  - id: read-context
-    tools: [Read]
-`),
-)
-
-const guard = new Edictum({ workflowRuntime })
-```
 
 ## What You Can Do
 
@@ -159,6 +187,22 @@ const guard = new Edictum({ rules: [noRm] })
 **Callbacks** — `onDeny` / `onAllow` for logging and observability. For human-in-the-loop approvals, use `approvalBackend`.
 
 **Observe mode** — log what would be blocked without blocking, then switch to enforce.
+
+## Enterprise Profiles
+
+Enterprises usually document an agent profile before they ship it: low, medium, or high agency; read-only, write-only, or read-write permissions; approved tools; allowed data operations; and process requirements.
+
+Edictum makes any agency level defensible. Medium Agency is the enterprise demand center right now because those agents can act on systems of record but still need explicit boundaries.
+
+Rulesets and Workflow Gates turn the profile into executable controls:
+
+- **Low agency:** read-only tools, narrow data access, mostly call-level rules.
+- **Medium agency:** read-write or scoped write operations, staged Workflow Gates, evidence checks, approvals at irreversible steps.
+- **High agency:** broader tool access with stricter runtime enforcement, session limits, approvals, audit, and post-execution checks.
+
+## Measurement Boundary
+
+Edictum measures behavioral conformance to a declared profile. It does not replace output-quality evals such as accuracy, relevance, coherence, or answer quality.
 
 ## Edictum Control Plane
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "overrides": {
       "@hono/node-server": "^1.19.10",
       "fast-xml-parser": "^5.5.6",
-      "flatted": "^3.4.2"
+      "flatted": "^3.4.2",
+      "protobufjs": "7.5.5"
     }
   },
   "devDependencies": {

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -1,8 +1,10 @@
 # @edictum/claude-sdk
 
-Claude Agent SDK adapter for Edictum rule enforcement.
+Claude Agent SDK adapter for Edictum agency-boundary enforcement.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Agent frameworks build the agent. Edictum bounds the agency. This package composes Edictum with Claude SDK tool hooks while the core pipeline enforces rulesets and Workflow Gates.
 
 ## Install
 

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/claude-sdk",
   "version": "0.2.1",
-  "description": "Claude Agent SDK adapter for edictum",
+  "description": "Claude Agent SDK adapter for Edictum agency-boundary enforcement",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,12 @@
 # @edictum/core
 
-Runtime rule enforcement for AI agent tool calls. One runtime dep ([js-yaml](https://github.com/nodeca/js-yaml)).
+Runtime agency-boundary enforcement for production AI agents. One runtime dep ([js-yaml](https://github.com/nodeca/js-yaml)).
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Agent frameworks build the agent. Edictum bounds the agency.
+
+`@edictum/core` turns documented agent profiles into executable runtime boundaries for tools, data operations, workflow stage, evidence, approvals, and audit.
 
 ## Install
 
@@ -11,6 +15,8 @@ pnpm add @edictum/core
 ```
 
 ## Usage
+
+This is single tool-call enforcement. For ordered process enforcement, use `WorkflowRuntime` and Workflow Gates with the same `Edictum` instance.
 
 ```typescript
 import { readFile } from 'node:fs/promises'
@@ -37,9 +43,13 @@ try {
 - `RedactionPolicy` — sensitive field redaction for audit events
 - `CollectingAuditSink`, `StdoutAuditSink`, `FileAuditSink`, `CompositeSink` — audit sinks
 - `createEnvelope`, `ToolCall`, `SideEffect` — tool-call construction and metadata
-- `WorkflowRuntime`, `loadWorkflow`, `loadWorkflowString` — stateful multi-stage gate evaluation and YAML loaders
+- `WorkflowRuntime`, `loadWorkflow`, `loadWorkflowString` — Workflow Gates for ordered stage enforcement, evidence, and approvals
 - `composeBundles`, `loadBundle`, `compileContracts` — YAML engine helpers
 - `createViolation`, `buildViolations`, `Violation` — output-check violation helpers
+
+## Measurement Boundary
+
+Edictum measures behavioral conformance to a declared profile. It does not replace output-quality evals such as accuracy, relevance, coherence, or answer quality.
 
 ## Links
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/core",
   "version": "0.5.0",
-  "description": "Runtime rule enforcement for AI agent tool calls",
+  "description": "Agency-boundary runtime for production AI agents",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -45,11 +45,13 @@
   "keywords": [
     "ai",
     "agents",
-    "governance",
+    "edictum",
+    "agency-control",
+    "runtime-enforcement",
+    "rulesets",
+    "workflow-gates",
     "safety",
-    "contracts",
-    "tool-calling",
-    "guardrails"
+    "tool-calling"
   ],
   "repository": {
     "type": "git",

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -1,8 +1,10 @@
 # @edictum/langchain
 
-LangChain.js adapter for Edictum rule enforcement.
+LangChain.js adapter for Edictum agency-boundary enforcement.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Agent frameworks build the agent. Edictum bounds the agency. This package composes Edictum with LangChain.js tool middleware while the core pipeline enforces rulesets and Workflow Gates.
 
 ## Install
 

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/langchain",
   "version": "0.2.1",
-  "description": "LangChain.js adapter for edictum",
+  "description": "LangChain.js adapter for Edictum agency-boundary enforcement",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/openai-agents/README.md
+++ b/packages/openai-agents/README.md
@@ -1,8 +1,10 @@
 # @edictum/openai-agents
 
-OpenAI Agents SDK adapter for Edictum rule enforcement.
+OpenAI Agents SDK adapter for Edictum agency-boundary enforcement.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Agent frameworks build the agent. Edictum bounds the agency. This package composes Edictum with OpenAI Agents SDK hooks while the core pipeline enforces rulesets and Workflow Gates.
 
 ## Install
 

--- a/packages/openai-agents/package.json
+++ b/packages/openai-agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/openai-agents",
   "version": "0.2.1",
-  "description": "OpenAI Agents SDK adapter for edictum",
+  "description": "OpenAI Agents SDK adapter for Edictum agency-boundary enforcement",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -1,8 +1,10 @@
 # @edictum/otel
 
-OpenTelemetry integration for Edictum rule enforcement.
+OpenTelemetry integration for Edictum behavioral conformance signals.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Use this package to emit spans and metrics for runtime enforcement decisions. Edictum measures behavioral conformance to a declared profile, not output quality such as accuracy, relevance, coherence, or answer quality.
 
 ## Install
 

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/otel",
   "version": "0.2.1",
-  "description": "OpenTelemetry integration for Edictum rule enforcement",
+  "description": "OpenTelemetry integration for Edictum behavioral conformance signals",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -89,7 +89,7 @@
     "opentelemetry",
     "otel",
     "observability",
-    "governance"
+    "behavioral-conformance"
   ],
   "repository": {
     "type": "git",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,8 +1,10 @@
 # @edictum/server
 
-Server SDK for connecting Edictum-governed agents to the Edictum API.
+Server SDK for connecting Edictum-enforced agents to the Edictum API.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Use this package when rulesets, Workflow Gates, approvals, audit events, and live updates should come from the Edictum API instead of local files.
 
 ## Install
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/server",
   "version": "0.4.1",
-  "description": "Server SDK (HTTP client, SSE, audit sink) for edictum",
+  "description": "Server SDK for Edictum agency boundaries, approvals, and audit",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -1,8 +1,10 @@
 # @edictum/vercel-ai
 
-Vercel AI SDK adapter for Edictum rule enforcement.
+Vercel AI SDK adapter for Edictum agency-boundary enforcement.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts) — runtime rule enforcement for AI agent tool calls.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+
+Agent frameworks build the agent. Edictum bounds the agency. This package composes Edictum with Vercel AI SDK tool callbacks while the core pipeline enforces rulesets and Workflow Gates.
 
 ## Install
 

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/vercel-ai",
   "version": "0.3.1",
-  "description": "Vercel AI SDK adapter for edictum",
+  "description": "Vercel AI SDK adapter for Edictum agency-boundary enforcement",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@hono/node-server': ^1.19.10
   fast-xml-parser: ^5.5.6
   flatted: ^3.4.2
+  protobufjs: 7.5.5
 
 importers:
 
@@ -1901,8 +1902,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -2513,7 +2514,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@hono/node-server@1.19.11(hono@4.12.7)':
@@ -2814,7 +2815,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4047,7 +4048,7 @@ snapshots:
 
   prettier@3.8.1: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
- Reposition the SDK README around Edictum as the agency control layer for production AI agents.
- Keep the TypeScript quickstart as single tool-call enforcement and add a Workflow Gates example for stage, evidence, approval, and audit boundaries.
- Update package-facing READMEs and package metadata around agency boundaries, runtime enforcement, and behavioral conformance.
- Pin `protobufjs` to patched version `7.5.5` through pnpm overrides to clear the critical audit failure in CI.

## Validation
- pnpm build
- pnpm lint
- pnpm test
- pnpm audit --audit-level=critical
- Pre-commit hook passed build, lint, format:check, typecheck, and test for both commits.
- GitHub checks are green: ci, validate, gate / Tests (node 22), gate / Conformance (node), review, and post.
- rg -n "contract|contracts|denied|deny|runtime contract|guardrails" README.md packages docs was run; docs/ does not exist, and remaining hits are internal source/test/API terms under packages.