### PR TITLE
fix(claude-sdk): emit SDK-native hook matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const { inputGuardrail, outputGuardrail } = adapter.asGuardrails()
 ```typescript
 import { ClaudeAgentSDKAdapter } from '@edictum/claude-sdk'
 const adapter = new ClaudeAgentSDKAdapter(guard)
-const { PreToolUse, PostToolUse } = adapter.toSdkHooks()
+const options = { hooks: adapter.toSdkHooks() }
 ```
 
 **LangChain.js** — middleware for ToolNode:
@@ -154,7 +154,7 @@ const middleware = adapter.asMiddleware()
 
 Adapters are thin wrappers. All rule enforcement logic lives in the pipeline.
 
-> **Output-check enforcement:** `guard.run()` guarantees full output-check enforcement. Native adapter hooks enforce preconditions deterministically; redact behavior after execution depends on SDK support. See adapter docs for per-SDK details.
+> **Output-check enforcement:** `guard.run()` guarantees full output-check enforcement. Native adapter hooks enforce preconditions deterministically; redact behavior after execution depends on SDK support. Claude Agent SDK native-hook postconditions are detection/warning only because replacement output must preserve each tool's result schema. See adapter docs for per-SDK details.
 
 ## What You Can Do
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ const { inputGuardrail, outputGuardrail } = adapter.asGuardrails()
 ```typescript
 import { ClaudeAgentSDKAdapter } from '@edictum/claude-sdk'
 const adapter = new ClaudeAgentSDKAdapter(guard)
-const options = { hooks: adapter.toSdkHooks() }
+const options = {
+  allowedTools: ['Read'],
+  hooks: adapter.toSdkHooks(),
+}
 ```
 
 **LangChain.js** — middleware for ToolNode:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "@hono/node-server": "^1.19.10",
       "fast-xml-parser": "^5.5.6",
       "flatted": "^3.4.2",
-      "protobufjs": "7.5.5"
+      "protobufjs": "7.5.5",
+      "vitest": "3.2.6"
     }
   },
   "devDependencies": {

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -51,7 +51,15 @@ they cannot undo filesystem, network, or other side effects. Native hook postcon
 and warning only for both built-in and MCP tools. The SDK's supported replacement field is
 `updatedToolOutput`, but its value must preserve the invoked tool's result schema. Edictum's generic
 redact/deny result does not carry enough schema information to do that safely, so the adapter does not
-claim output suppression. Use a precondition when an action or its output must be blocked.
+claim output suppression. Both `PostToolUse` and `PostToolUseFailure` finalize pending calls so failed
+tools still run postconditions, fire warnings, and attempt failure audit emission. An SDK failure event
+is authoritative and cannot be overridden by a custom success check. Use a precondition when an
+action or its output must be blocked.
+
+Post finalization is at-most-once. If a postcondition, workflow store, session store, or audit sink
+throws, the hook propagates that error but does not retry: those ports do not share a transaction or
+idempotency key, and retry could duplicate durable state. This is a core transaction-boundary gap,
+not a claim that failure audit is guaranteed.
 
 ## Links
 

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -21,13 +21,11 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 
 const guard = Edictum.fromYaml('rules.yaml')
 const adapter = new ClaudeAgentSDKAdapter(guard)
-const permissionHandler = async () => ({ behavior: 'allow' as const })
 
 for await (const message of query({
   prompt: 'Inspect this repository',
   options: {
     hooks: adapter.toSdkHooks(),
-    canUseTool: adapter.wrapCanUseTool(permissionHandler),
   },
 })) {
   // Consume SDK messages.
@@ -60,6 +58,13 @@ results, rejects replacements, and converts thrown or malformed callback results
 The live verification has a permission callback rewrite a benign command to a forbidden `touch` and
 proves that the wrapper blocks it.
 
+```typescript
+const options = {
+  hooks: adapter.toSdkHooks(),
+  canUseTool: adapter.wrapCanUseTool(permissionHandler),
+}
+```
+
 Postconditions execute after the tool, so
 they cannot undo filesystem, network, or other side effects. Native hook postconditions are detection
 and warning only for both built-in and MCP tools. The SDK's supported replacement field is
@@ -67,8 +72,8 @@ and warning only for both built-in and MCP tools. The SDK's supported replacemen
 redact/deny result does not carry enough schema information to do that safely, so the adapter does not
 claim output suppression. Both `PostToolUse` and `PostToolUseFailure` finalize pending calls so failed
 tools still run postconditions, fire warnings, and attempt failure audit emission. An SDK failure event
-is authoritative and cannot be overridden by a custom success check. Use a precondition when a tool
-call or its output must be blocked.
+is authoritative and cannot be overridden by a custom success check. Use a precondition to prevent a
+tool call. Suppressing a completed tool result requires a separate schema-aware wrapper.
 
 Post finalization is at-most-once. If a postcondition, workflow store, session store, or audit sink
 throws, the hook propagates that error but does not retry: those ports do not share a transaction or

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -1,10 +1,10 @@
 # @edictum/claude-sdk
 
-Claude Agent SDK adapter for Edictum agency-boundary enforcement.
+Claude Agent SDK adapter for Edictum runtime rule enforcement on AI agent tool calls.
 
-Part of [Edictum](https://github.com/edictum-ai/edictum-ts): the agency control layer for production AI agents.
+Part of [Edictum](https://github.com/edictum-ai/edictum-ts): runtime rule enforcement for AI agent tool calls in production.
 
-Agent frameworks build the agent. Edictum bounds the agency. This package composes Edictum with Claude SDK tool hooks while the core pipeline enforces rulesets and Workflow Gates.
+This package composes Edictum with Claude SDK tool hooks while the core pipeline enforces rulesets and Workflow Gates.
 
 ## Install
 
@@ -57,8 +57,8 @@ permission callback can bypass governance. Always pass configured callbacks thro
 objects, preserves documented null responses, rejects input and permission mutations, and converts
 thrown or malformed callback results to a fixed denial. It deliberately does not forward
 `updatedPermissions`; pre-approve stable permissions through SDK options instead.
-The live verification has a permission callback rewrite a benign command to a forbidden `touch` and
-proves that the wrapper blocks it.
+The live verification has a permission callback mutate a detached copy of a benign command to a
+forbidden `touch` and proves that the SDK executes the original governed input unchanged.
 
 ```typescript
 const options = {

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -53,8 +53,10 @@ Preconditions execute before the tool and can block it. Passing an Edictum preco
 approve the call: the SDK still applies `allowedTools`, `canUseTool`, and its normal permission path.
 The pinned SDK executes a `canUseTool` `updatedInput` without another `PreToolUse` callback, so a raw
 permission callback can bypass governance. Always pass configured callbacks through
-`adapter.wrapCanUseTool(callback)`. The wrapper preserves normal allow, deny, and documented null
-results, rejects replacements, and converts thrown or malformed callback results to a fixed denial.
+`adapter.wrapCanUseTool(callback)`. The wrapper copies normal allow and deny results into fresh plain
+objects, preserves documented null responses, rejects input and permission mutations, and converts
+thrown or malformed callback results to a fixed denial. It deliberately does not forward
+`updatedPermissions`; pre-approve stable permissions through SDK options instead.
 The live verification has a permission callback rewrite a benign command to a forbidden `touch` and
 proves that the wrapper blocks it.
 

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -17,19 +17,41 @@ pnpm add @edictum/claude-sdk @edictum/core
 ```typescript
 import { Edictum } from '@edictum/core'
 import { ClaudeAgentSDKAdapter } from '@edictum/claude-sdk'
+import { query } from '@anthropic-ai/claude-agent-sdk'
 
 const guard = Edictum.fromYaml('rules.yaml')
 const adapter = new ClaudeAgentSDKAdapter(guard)
-const { PreToolUse, PostToolUse } = adapter.toSdkHooks()
+
+for await (const message of query({
+  prompt: 'Inspect this repository',
+  options: {
+    hooks: adapter.toSdkHooks(),
+  },
+})) {
+  // Consume SDK messages.
+}
 ```
 
 ## API
 
 - `ClaudeAgentSDKAdapter` — adapter class
-  - `toSdkHooks(options?)` — returns `{ PreToolUse, PostToolUse }` hook callback arrays
+  - `toSdkHooks(options?)` — returns the SDK-native `hooks` object. This is a breaking change from
+    the 0.2.x shape: each event now contains hook matcher objects, not bare callback arrays.
   - `setPrincipal(principal)` — update principal mid-session
 - `ClaudeAgentSDKAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
 - `ToSdkHooksOptions` — `{ onPostconditionWarn }` callback
+
+The exported hook type aliases now also resolve to the SDK-native types. Code that imported the old
+structural `HookCallback`, input, or output aliases must update to the native three-argument callback
+and required SDK input fields. Code that only passed `toSdkHooks()` to `options.hooks` needs no
+additional bridge.
+
+Preconditions execute before the tool and can deny it. Postconditions execute after the tool, so
+they cannot undo filesystem, network, or other side effects. Native hook postconditions are detection
+and warning only for both built-in and MCP tools. The SDK's supported replacement field is
+`updatedToolOutput`, but its value must preserve the invoked tool's result schema. Edictum's generic
+redact/deny result does not carry enough schema information to do that safely, so the adapter does not
+claim output suppression. Use a precondition when an action or its output must be blocked.
 
 ## Links
 

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -21,11 +21,13 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 
 const guard = Edictum.fromYaml('rules.yaml')
 const adapter = new ClaudeAgentSDKAdapter(guard)
+const permissionHandler = async () => ({ behavior: 'allow' as const })
 
 for await (const message of query({
   prompt: 'Inspect this repository',
   options: {
     hooks: adapter.toSdkHooks(),
+    canUseTool: adapter.wrapCanUseTool(permissionHandler),
   },
 })) {
   // Consume SDK messages.
@@ -38,6 +40,8 @@ for await (const message of query({
   - `toSdkHooks(options?)` — returns the SDK-native `hooks` object. This is a breaking change from
     the 0.2.x shape: each event now contains hook matcher objects, not bare callback arrays. The
     corrected API ships as 0.3.0.
+  - `wrapCanUseTool(callback)` — wraps an SDK permission callback and rejects `updatedInput`
+    replacements after governance. Use it for every configured `canUseTool` callback.
   - `setPrincipal(principal)` — update principal mid-session
 - `ClaudeAgentSDKAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
 - `ToSdkHooksOptions` — `{ onPostconditionWarn }` callback
@@ -49,6 +53,13 @@ additional bridge.
 
 Preconditions execute before the tool and can block it. Passing an Edictum precondition does not
 approve the call: the SDK still applies `allowedTools`, `canUseTool`, and its normal permission path.
+The pinned SDK executes a `canUseTool` `updatedInput` without another `PreToolUse` callback, so a raw
+permission callback can bypass governance. Always pass configured callbacks through
+`adapter.wrapCanUseTool(callback)`. The wrapper preserves normal allow, deny, and documented null
+results, rejects replacements, and converts thrown or malformed callback results to a fixed denial.
+The live verification has a permission callback rewrite a benign command to a forbidden `touch` and
+proves that the wrapper blocks it.
+
 Postconditions execute after the tool, so
 they cannot undo filesystem, network, or other side effects. Native hook postconditions are detection
 and warning only for both built-in and MCP tools. The SDK's supported replacement field is

--- a/packages/claude-sdk/README.md
+++ b/packages/claude-sdk/README.md
@@ -36,7 +36,8 @@ for await (const message of query({
 
 - `ClaudeAgentSDKAdapter` — adapter class
   - `toSdkHooks(options?)` — returns the SDK-native `hooks` object. This is a breaking change from
-    the 0.2.x shape: each event now contains hook matcher objects, not bare callback arrays.
+    the 0.2.x shape: each event now contains hook matcher objects, not bare callback arrays. The
+    corrected API ships as 0.3.0.
   - `setPrincipal(principal)` — update principal mid-session
 - `ClaudeAgentSDKAdapterOptions` — constructor options (`sessionId`, `principal`, `principalResolver`)
 - `ToSdkHooksOptions` — `{ onPostconditionWarn }` callback
@@ -46,15 +47,17 @@ structural `HookCallback`, input, or output aliases must update to the native th
 and required SDK input fields. Code that only passed `toSdkHooks()` to `options.hooks` needs no
 additional bridge.
 
-Preconditions execute before the tool and can deny it. Postconditions execute after the tool, so
+Preconditions execute before the tool and can block it. Passing an Edictum precondition does not
+approve the call: the SDK still applies `allowedTools`, `canUseTool`, and its normal permission path.
+Postconditions execute after the tool, so
 they cannot undo filesystem, network, or other side effects. Native hook postconditions are detection
 and warning only for both built-in and MCP tools. The SDK's supported replacement field is
 `updatedToolOutput`, but its value must preserve the invoked tool's result schema. Edictum's generic
 redact/deny result does not carry enough schema information to do that safely, so the adapter does not
 claim output suppression. Both `PostToolUse` and `PostToolUseFailure` finalize pending calls so failed
 tools still run postconditions, fire warnings, and attempt failure audit emission. An SDK failure event
-is authoritative and cannot be overridden by a custom success check. Use a precondition when an
-action or its output must be blocked.
+is authoritative and cannot be overridden by a custom success check. Use a precondition when a tool
+call or its output must be blocked.
 
 Post finalization is at-most-once. If a postcondition, workflow store, session store, or audit sink
 throws, the hook propagates that error but does not retry: those ports do not share a transaction or

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edictum/claude-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Claude Agent SDK adapter for Edictum agency-boundary enforcement",
   "license": "MIT",
   "type": "module",

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -24,22 +24,26 @@
     "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
+    "verify:live-hooks": "node scripts/live-sdk-hook-proof.mjs",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@edictum/core": ">=0.3.0 <0.6.0",
-    "@anthropic-ai/claude-agent-sdk": ">=0.1.0"
+    "@anthropic-ai/claude-agent-sdk": ">=0.3.221 <0.4.0",
+    "@edictum/core": ">=0.3.0 <0.6.0"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.221",
+    "@anthropic-ai/sdk": "0.115.0",
     "@edictum/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@types/node": "^25.5.0",
+    "eslint": "^10.1.0",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "eslint": "^10.1.0",
-    "typescript-eslint": "^8.57.2"
+    "typescript-eslint": "^8.57.2",
+    "vitest": "^3.0.0"
   },
   "keywords": [
     "ai",

--- a/packages/claude-sdk/package.json
+++ b/packages/claude-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edictum/claude-sdk",
   "version": "0.3.0",
-  "description": "Claude Agent SDK adapter for Edictum agency-boundary enforcement",
+  "description": "Claude Agent SDK adapter for Edictum runtime rule enforcement on AI agent tool calls",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -6,8 +6,14 @@ import { AuditAction, CollectingAuditSink, Decision, Edictum } from '@edictum/co
 import { ClaudeAgentSDKAdapter } from '../dist/index.mjs'
 
 const mode = process.argv[2]
-if (mode !== 'control' && mode !== 'block' && mode !== 'post' && mode !== 'failure') {
-  console.error('usage: pnpm verify:live-hooks <control|block|post|failure>')
+if (
+  mode !== 'control' &&
+  mode !== 'block' &&
+  mode !== 'permission' &&
+  mode !== 'post' &&
+  mode !== 'failure'
+) {
+  console.error('usage: pnpm verify:live-hooks <control|block|permission|post|failure>')
   process.exit(2)
 }
 
@@ -27,6 +33,7 @@ let returnedHookOutputKeys = 'NOT_CALLED'
 let assistantText = ''
 let sdkResult = 'NOT_EMITTED'
 let failureHookCalled = false
+let permissionCallbackCalled = false
 const postProbe = 'POSTCONDITION_PROBE_VALUE'
 const auditSink = new CollectingAuditSink()
 const denyTouch = {
@@ -64,7 +71,13 @@ const warnOnFailure = {
 
 const guard = new Edictum({
   rules:
-    mode === 'post' ? [suppressProbeOutput] : mode === 'failure' ? [warnOnFailure] : [denyTouch],
+    mode === 'post'
+      ? [suppressProbeOutput]
+      : mode === 'failure'
+        ? [warnOnFailure]
+        : mode === 'permission'
+          ? []
+          : [denyTouch],
   tools: mode === 'post' ? { Read: { side_effect: 'read' } } : { Bash: { side_effect: 'execute' } },
   auditSink,
   onDeny: () => {
@@ -113,16 +126,26 @@ if (mode === 'failure') {
 }
 
 const options = {
-  allowedTools: [mode === 'post' ? 'Read' : 'Bash'],
+  ...(mode === 'permission' ? {} : { allowedTools: [mode === 'post' ? 'Read' : 'Bash'] }),
   permissionMode: 'acceptEdits',
   settingSources: [],
   maxTurns: 2,
+  ...(mode === 'permission'
+    ? {
+        canUseTool: async () => {
+          permissionCallbackCalled = true
+          return { behavior: 'deny', message: 'live proof SDK permission denial' }
+        },
+      }
+    : {}),
   ...(mode === 'control' ? {} : { hooks }),
 }
 
 console.log(`MODE=${mode}`)
 console.log('SDK=@anthropic-ai/claude-agent-sdk@0.3.221')
-console.log(`PREAPPROVED_TOOLS=${mode === 'post' ? 'Read' : 'Bash'}`)
+console.log(
+  `PREAPPROVED_TOOLS=${mode === 'permission' ? 'NONE' : mode === 'post' ? 'Read' : 'Bash'}`,
+)
 console.log(`HOOKS=${mode === 'control' ? 'REMOVED' : 'ADAPTER'}`)
 
 for await (const message of query({
@@ -170,23 +193,28 @@ if (mode === 'failure') {
   console.log(`POSTCONDITION_WARNED=${postconditionWarned ? 'YES' : 'NO'}`)
   console.log(`CALL_FAILED_AUDIT_COUNT=${auditSink.filter(AuditAction.CALL_FAILED).length}`)
 }
+if (mode === 'permission') {
+  console.log(`PERMISSION_CALLBACK_CALLED=${permissionCallbackCalled ? 'YES' : 'NO'}`)
+}
 
 const passed =
   mode === 'control'
     ? sdkResult === 'success' && present && !hookDenied
     : mode === 'block'
       ? sdkResult === 'success' && !present && hookDenied
-      : mode === 'post'
-        ? sdkResult === 'success' &&
-          postInputShape !== 'NOT_CALLED' &&
-          postInputContainedProbe &&
-          postconditionWarned &&
-          !returnedUpdatedToolOutput &&
-          assistantText.trim().endsWith('ORIGINAL')
-        : sdkResult === 'success' &&
-          failureHookCalled &&
-          postconditionWarned &&
-          auditSink.filter(AuditAction.CALL_FAILED).length === 1
+      : mode === 'permission'
+        ? sdkResult === 'success' && !present && !hookDenied && permissionCallbackCalled
+        : mode === 'post'
+          ? sdkResult === 'success' &&
+            postInputShape !== 'NOT_CALLED' &&
+            postInputContainedProbe &&
+            postconditionWarned &&
+            !returnedUpdatedToolOutput &&
+            assistantText.trim().endsWith('ORIGINAL')
+          : sdkResult === 'success' &&
+            failureHookCalled &&
+            postconditionWarned &&
+            auditSink.filter(AuditAction.CALL_FAILED).length === 1
 if (!passed) {
   process.exitCode = 1
 }

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -1,0 +1,157 @@
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
+
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { Decision, Edictum } from '@edictum/core'
+
+import { ClaudeAgentSDKAdapter } from '../dist/index.mjs'
+
+const mode = process.argv[2]
+if (mode !== 'control' && mode !== 'block' && mode !== 'post') {
+  console.error('usage: pnpm verify:live-hooks <control|block|post>')
+  process.exit(2)
+}
+
+const sentinel = '/tmp/edictum-ts-claude-sdk-hook-sentinel'
+const postProbeFile = `/tmp/edictum-ts-claude-sdk-post-probe-${process.pid}`
+if (existsSync(sentinel)) {
+  unlinkSync(sentinel)
+}
+
+let hookDenied = false
+let postInputShape = 'NOT_CALLED'
+let postInputKeys = 'NOT_CALLED'
+let postInputContainedProbe = false
+let postconditionWarned = false
+let returnedUpdatedToolOutput = false
+let returnedHookOutputKeys = 'NOT_CALLED'
+let assistantText = ''
+let sdkResult = 'NOT_EMITTED'
+const postProbe = 'POSTCONDITION_PROBE_VALUE'
+const denyTouch = {
+  tool: 'Bash',
+  check: async (toolCall) => {
+    const command = toolCall.args.command
+    if (typeof command === 'string' && command.includes('touch') && command.includes(sentinel)) {
+      return Decision.fail('live proof denies sentinel creation')
+    }
+    return Decision.pass_()
+  },
+}
+const suppressProbeOutput = {
+  _edictum_type: 'postcondition',
+  type: 'postcondition',
+  name: 'live_postcondition_probe',
+  tool: 'Read',
+  effect: 'deny',
+  check: async (_toolCall, output) =>
+    JSON.stringify(output).includes(postProbe)
+      ? Decision.fail('live proof suppresses Read output')
+      : Decision.pass_(),
+}
+
+const guard = new Edictum({
+  rules: mode === 'post' ? [suppressProbeOutput] : [denyTouch],
+  tools: mode === 'post' ? { Read: { side_effect: 'read' } } : { Bash: { side_effect: 'execute' } },
+  onDeny: () => {
+    hookDenied = true
+  },
+})
+const adapter = new ClaudeAgentSDKAdapter(guard, { sessionId: `live-${mode}` })
+const hooks = adapter.toSdkHooks({
+  onPostconditionWarn: () => {
+    postconditionWarned = true
+  },
+})
+
+if (mode === 'post') {
+  writeFileSync(postProbeFile, postProbe, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+  const originalPostHook = hooks.PostToolUse[0].hooks[0]
+  hooks.PostToolUse[0].hooks[0] = async (input, toolUseID, context) => {
+    if (input.hook_event_name === 'PostToolUse') {
+      postInputShape = Array.isArray(input.tool_response)
+        ? 'array'
+        : input.tool_response === null
+          ? 'null'
+          : typeof input.tool_response
+      postInputKeys =
+        typeof input.tool_response === 'object' && input.tool_response != null
+          ? Object.keys(input.tool_response).sort().join(',')
+          : 'NONE'
+      postInputContainedProbe = JSON.stringify(input.tool_response).includes(postProbe)
+    }
+    const output = await originalPostHook(input, toolUseID, context)
+    const hookOutput = output.hookSpecificOutput
+    returnedHookOutputKeys = hookOutput ? Object.keys(hookOutput).sort().join(',') : 'NONE'
+    returnedUpdatedToolOutput = Boolean(
+      hookOutput && Object.prototype.hasOwnProperty.call(hookOutput, 'updatedToolOutput'),
+    )
+    return output
+  }
+}
+
+const options = {
+  allowedTools: [mode === 'post' ? 'Read' : 'Bash'],
+  permissionMode: 'acceptEdits',
+  settingSources: [],
+  maxTurns: 2,
+  ...(mode === 'control' ? {} : { hooks }),
+}
+
+console.log(`MODE=${mode}`)
+console.log('SDK=@anthropic-ai/claude-agent-sdk@0.3.221')
+console.log(`PREAPPROVED_TOOLS=${mode === 'post' ? 'Read' : 'Bash'}`)
+console.log(`HOOKS=${mode === 'control' ? 'REMOVED' : 'ADAPTER'}`)
+
+for await (const message of query({
+  prompt:
+    mode === 'post'
+      ? `Use Read exactly once to read ${postProbeFile}. Then answer only SUPPRESSED if the tool output begins with [OUTPUT SUPPRESSED], otherwise answer only ORIGINAL.`
+      : `Use the Bash tool exactly once to run this exact command, then stop: touch ${sentinel}`,
+  options,
+})) {
+  if (message.type === 'assistant') {
+    assistantText += message.message.content
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n')
+  }
+  if (message.type === 'result') {
+    sdkResult = message.subtype
+    console.log(`SDK_RESULT=${message.subtype}`)
+  }
+}
+
+const present = existsSync(sentinel)
+if (mode === 'post' && existsSync(postProbeFile)) {
+  unlinkSync(postProbeFile)
+}
+console.log(`HOOK_DENIED=${hookDenied ? 'YES' : 'NO'}`)
+console.log(`SENTINEL=${present ? 'PRESENT' : 'ABSENT'}`)
+
+if (mode === 'post') {
+  console.log(`POST_INPUT_SHAPE=${postInputShape}`)
+  console.log(`POST_INPUT_KEYS=${postInputKeys}`)
+  console.log(`POST_INPUT_CONTAINED_PROBE=${postInputContainedProbe ? 'YES' : 'NO'}`)
+  console.log(`POSTCONDITION_WARNED=${postconditionWarned ? 'YES' : 'NO'}`)
+  console.log(`UPDATED_TOOL_OUTPUT_RETURNED=${returnedUpdatedToolOutput ? 'YES' : 'NO'}`)
+  console.log(`HOOK_OUTPUT_KEYS=${returnedHookOutputKeys}`)
+  console.log(
+    `MODEL_REPORTED_SUPPRESSED=${assistantText.trim().endsWith('SUPPRESSED') ? 'YES' : 'NO'}`,
+  )
+  console.log(`MODEL_REPORTED_ORIGINAL=${assistantText.trim().endsWith('ORIGINAL') ? 'YES' : 'NO'}`)
+}
+
+const passed =
+  mode === 'control'
+    ? sdkResult === 'success' && present && !hookDenied
+    : mode === 'block'
+      ? sdkResult === 'success' && !present && hookDenied
+      : sdkResult === 'success' &&
+        postInputShape !== 'NOT_CALLED' &&
+        postInputContainedProbe &&
+        postconditionWarned &&
+        !returnedUpdatedToolOutput &&
+        assistantText.trim().endsWith('ORIGINAL')
+if (!passed) {
+  process.exitCode = 1
+}

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -18,9 +18,13 @@ if (
 }
 
 const sentinel = '/tmp/edictum-ts-claude-sdk-hook-sentinel'
+const permissionOriginalSentinel = `/tmp/edictum-ts-claude-sdk-permission-original-${process.pid}`
 const postProbeFile = `/tmp/edictum-ts-claude-sdk-post-probe-${process.pid}`
 if (existsSync(sentinel)) {
   unlinkSync(sentinel)
+}
+if (existsSync(permissionOriginalSentinel)) {
+  unlinkSync(permissionOriginalSentinel)
 }
 
 let hookDenied = false
@@ -34,6 +38,8 @@ let assistantText = ''
 let sdkResult = 'NOT_EMITTED'
 let failureHookCalled = false
 let permissionCallbackCalled = false
+let permissionRewriteRejected = false
+let preHookObservedRewrittenInput = false
 const postProbe = 'POSTCONDITION_PROBE_VALUE'
 const auditSink = new CollectingAuditSink()
 const denyTouch = {
@@ -51,7 +57,7 @@ const suppressProbeOutput = {
   type: 'postcondition',
   name: 'live_postcondition_probe',
   tool: 'Read',
-  effect: 'deny',
+  action: 'block',
   check: async (_toolCall, output) =>
     JSON.stringify(output).includes(postProbe)
       ? Decision.fail('live proof suppresses Read output')
@@ -62,7 +68,7 @@ const warnOnFailure = {
   type: 'postcondition',
   name: 'live_failure_probe',
   tool: 'Bash',
-  effect: 'deny',
+  action: 'block',
   check: async (_toolCall, output) =>
     typeof output === 'object' && output != null && output.is_error === true
       ? Decision.fail('live proof observed failed Bash execution')
@@ -125,6 +131,15 @@ if (mode === 'failure') {
   }
 }
 
+if (mode === 'permission') {
+  const originalPreToolUseHook = hooks.PreToolUse[0].hooks[0]
+  hooks.PreToolUse[0].hooks[0] = async (input, toolUseID, context) => {
+    preHookObservedRewrittenInput ||=
+      input.hook_event_name === 'PreToolUse' && input.tool_input.command === `touch ${sentinel}`
+    return originalPreToolUseHook(input, toolUseID, context)
+  }
+}
+
 const options = {
   ...(mode === 'permission' ? {} : { allowedTools: [mode === 'post' ? 'Read' : 'Bash'] }),
   permissionMode: 'acceptEdits',
@@ -132,9 +147,13 @@ const options = {
   maxTurns: 2,
   ...(mode === 'permission'
     ? {
-        canUseTool: async () => {
-          permissionCallbackCalled = true
-          return { behavior: 'deny', message: 'live proof SDK permission denial' }
+        canUseTool: async (...args) => {
+          const result = await adapter.wrapCanUseTool(async () => {
+            permissionCallbackCalled = true
+            return { behavior: 'allow', updatedInput: { command: `touch ${sentinel}` } }
+          })(...args)
+          permissionRewriteRejected = result?.behavior === 'deny'
+          return result
         },
       }
     : {}),
@@ -154,7 +173,9 @@ for await (const message of query({
       ? `Use Read exactly once to read ${postProbeFile}. Then answer only SUPPRESSED if the tool output begins with [OUTPUT SUPPRESSED], otherwise answer only ORIGINAL.`
       : mode === 'failure'
         ? 'Use the Bash tool exactly once to run this exact command, then stop: exit 7'
-        : `Use the Bash tool exactly once to run this exact command, then stop: touch ${sentinel}`,
+        : mode === 'permission'
+          ? `Use the Bash tool exactly once to run this exact command, then stop: touch ${permissionOriginalSentinel}`
+          : `Use the Bash tool exactly once to run this exact command, then stop: touch ${sentinel}`,
   options,
 })) {
   if (message.type === 'assistant') {
@@ -170,6 +191,9 @@ for await (const message of query({
 }
 
 const present = existsSync(sentinel)
+if (existsSync(permissionOriginalSentinel)) {
+  unlinkSync(permissionOriginalSentinel)
+}
 if (mode === 'post' && existsSync(postProbeFile)) {
   unlinkSync(postProbeFile)
 }
@@ -195,6 +219,8 @@ if (mode === 'failure') {
 }
 if (mode === 'permission') {
   console.log(`PERMISSION_CALLBACK_CALLED=${permissionCallbackCalled ? 'YES' : 'NO'}`)
+  console.log(`PERMISSION_REWRITE_REJECTED=${permissionRewriteRejected ? 'YES' : 'NO'}`)
+  console.log(`PRE_HOOK_SAW_REWRITTEN_INPUT=${preHookObservedRewrittenInput ? 'YES' : 'NO'}`)
 }
 
 const passed =
@@ -203,7 +229,12 @@ const passed =
     : mode === 'block'
       ? sdkResult === 'success' && !present && hookDenied
       : mode === 'permission'
-        ? sdkResult === 'success' && !present && !hookDenied && permissionCallbackCalled
+        ? sdkResult === 'success' &&
+          !present &&
+          !hookDenied &&
+          permissionCallbackCalled &&
+          permissionRewriteRejected &&
+          !preHookObservedRewrittenInput
         : mode === 'post'
           ? sdkResult === 'success' &&
             postInputShape !== 'NOT_CALLED' &&

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -17,7 +17,7 @@ if (
   process.exit(2)
 }
 
-const sentinel = '/tmp/edictum-ts-claude-sdk-hook-sentinel'
+const sentinel = `/tmp/edictum-ts-claude-sdk-hook-sentinel-${process.pid}`
 const permissionOriginalSentinel = `/tmp/edictum-ts-claude-sdk-permission-original-${process.pid}`
 const postProbeFile = `/tmp/edictum-ts-claude-sdk-post-probe-${process.pid}`
 if (existsSync(sentinel)) {

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -1,13 +1,13 @@
 import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
 
 import { query } from '@anthropic-ai/claude-agent-sdk'
-import { Decision, Edictum } from '@edictum/core'
+import { AuditAction, CollectingAuditSink, Decision, Edictum } from '@edictum/core'
 
 import { ClaudeAgentSDKAdapter } from '../dist/index.mjs'
 
 const mode = process.argv[2]
-if (mode !== 'control' && mode !== 'block' && mode !== 'post') {
-  console.error('usage: pnpm verify:live-hooks <control|block|post>')
+if (mode !== 'control' && mode !== 'block' && mode !== 'post' && mode !== 'failure') {
+  console.error('usage: pnpm verify:live-hooks <control|block|post|failure>')
   process.exit(2)
 }
 
@@ -26,7 +26,9 @@ let returnedUpdatedToolOutput = false
 let returnedHookOutputKeys = 'NOT_CALLED'
 let assistantText = ''
 let sdkResult = 'NOT_EMITTED'
+let failureHookCalled = false
 const postProbe = 'POSTCONDITION_PROBE_VALUE'
+const auditSink = new CollectingAuditSink()
 const denyTouch = {
   tool: 'Bash',
   check: async (toolCall) => {
@@ -48,10 +50,23 @@ const suppressProbeOutput = {
       ? Decision.fail('live proof suppresses Read output')
       : Decision.pass_(),
 }
+const warnOnFailure = {
+  _edictum_type: 'postcondition',
+  type: 'postcondition',
+  name: 'live_failure_probe',
+  tool: 'Bash',
+  effect: 'deny',
+  check: async (_toolCall, output) =>
+    typeof output === 'object' && output != null && output.is_error === true
+      ? Decision.fail('live proof observed failed Bash execution')
+      : Decision.pass_(),
+}
 
 const guard = new Edictum({
-  rules: mode === 'post' ? [suppressProbeOutput] : [denyTouch],
+  rules:
+    mode === 'post' ? [suppressProbeOutput] : mode === 'failure' ? [warnOnFailure] : [denyTouch],
   tools: mode === 'post' ? { Read: { side_effect: 'read' } } : { Bash: { side_effect: 'execute' } },
+  auditSink,
   onDeny: () => {
     hookDenied = true
   },
@@ -89,6 +104,14 @@ if (mode === 'post') {
   }
 }
 
+if (mode === 'failure') {
+  const originalFailureHook = hooks.PostToolUseFailure[0].hooks[0]
+  hooks.PostToolUseFailure[0].hooks[0] = async (input, toolUseID, context) => {
+    failureHookCalled ||= input.hook_event_name === 'PostToolUseFailure'
+    return originalFailureHook(input, toolUseID, context)
+  }
+}
+
 const options = {
   allowedTools: [mode === 'post' ? 'Read' : 'Bash'],
   permissionMode: 'acceptEdits',
@@ -106,7 +129,9 @@ for await (const message of query({
   prompt:
     mode === 'post'
       ? `Use Read exactly once to read ${postProbeFile}. Then answer only SUPPRESSED if the tool output begins with [OUTPUT SUPPRESSED], otherwise answer only ORIGINAL.`
-      : `Use the Bash tool exactly once to run this exact command, then stop: touch ${sentinel}`,
+      : mode === 'failure'
+        ? 'Use the Bash tool exactly once to run this exact command, then stop: exit 7'
+        : `Use the Bash tool exactly once to run this exact command, then stop: touch ${sentinel}`,
   options,
 })) {
   if (message.type === 'assistant') {
@@ -140,18 +165,28 @@ if (mode === 'post') {
   )
   console.log(`MODEL_REPORTED_ORIGINAL=${assistantText.trim().endsWith('ORIGINAL') ? 'YES' : 'NO'}`)
 }
+if (mode === 'failure') {
+  console.log(`FAILURE_HOOK_CALLED=${failureHookCalled ? 'YES' : 'NO'}`)
+  console.log(`POSTCONDITION_WARNED=${postconditionWarned ? 'YES' : 'NO'}`)
+  console.log(`CALL_FAILED_AUDIT_COUNT=${auditSink.filter(AuditAction.CALL_FAILED).length}`)
+}
 
 const passed =
   mode === 'control'
     ? sdkResult === 'success' && present && !hookDenied
     : mode === 'block'
       ? sdkResult === 'success' && !present && hookDenied
-      : sdkResult === 'success' &&
-        postInputShape !== 'NOT_CALLED' &&
-        postInputContainedProbe &&
-        postconditionWarned &&
-        !returnedUpdatedToolOutput &&
-        assistantText.trim().endsWith('ORIGINAL')
+      : mode === 'post'
+        ? sdkResult === 'success' &&
+          postInputShape !== 'NOT_CALLED' &&
+          postInputContainedProbe &&
+          postconditionWarned &&
+          !returnedUpdatedToolOutput &&
+          assistantText.trim().endsWith('ORIGINAL')
+        : sdkResult === 'success' &&
+          failureHookCalled &&
+          postconditionWarned &&
+          auditSink.filter(AuditAction.CALL_FAILED).length === 1
 if (!passed) {
   process.exitCode = 1
 }

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -45,7 +45,7 @@ let assistantText = ''
 let sdkResult = 'NOT_EMITTED'
 let failureHookCalled = false
 let permissionCallbackCalled = false
-let permissionRewriteRejected = false
+let permissionMutationIsolated = false
 let preHookObservedRewrittenInput = false
 const postProbe = 'POSTCONDITION_PROBE_VALUE'
 const auditSink = new CollectingAuditSink()
@@ -155,11 +155,12 @@ const options = {
   ...(mode === 'permission'
     ? {
         canUseTool: async (...args) => {
-          const result = await adapter.wrapCanUseTool(async () => {
+          const result = await adapter.wrapCanUseTool(async (_toolName, input) => {
             permissionCallbackCalled = true
-            return { behavior: 'allow', updatedInput: { command: `touch ${sentinel}` } }
+            input.command = `touch ${sentinel}`
+            return { behavior: 'allow' }
           })(...args)
-          permissionRewriteRejected = result?.behavior === 'deny'
+          permissionMutationIsolated = result?.behavior === 'allow'
           return result
         },
       }
@@ -198,6 +199,7 @@ for await (const message of query({
 }
 
 const present = existsSync(sentinel)
+const permissionOriginalPresent = existsSync(permissionOriginalSentinel)
 if (existsSync(permissionOriginalSentinel)) {
   unlinkSync(permissionOriginalSentinel)
 }
@@ -226,7 +228,8 @@ if (mode === 'failure') {
 }
 if (mode === 'permission') {
   console.log(`PERMISSION_CALLBACK_CALLED=${permissionCallbackCalled ? 'YES' : 'NO'}`)
-  console.log(`PERMISSION_REWRITE_REJECTED=${permissionRewriteRejected ? 'YES' : 'NO'}`)
+  console.log(`PERMISSION_MUTATION_ISOLATED=${permissionMutationIsolated ? 'YES' : 'NO'}`)
+  console.log(`ORIGINAL_INPUT_EXECUTED=${permissionOriginalPresent ? 'YES' : 'NO'}`)
   console.log(`PRE_HOOK_SAW_REWRITTEN_INPUT=${preHookObservedRewrittenInput ? 'YES' : 'NO'}`)
 }
 
@@ -240,7 +243,8 @@ const passed =
           !present &&
           !hookDenied &&
           permissionCallbackCalled &&
-          permissionRewriteRejected &&
+          permissionMutationIsolated &&
+          permissionOriginalPresent &&
           !preHookObservedRewrittenInput
         : mode === 'post'
           ? sdkResult === 'success' &&

--- a/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
+++ b/packages/claude-sdk/scripts/live-sdk-hook-proof.mjs
@@ -17,7 +17,14 @@ if (
   process.exit(2)
 }
 
-const sentinel = `/tmp/edictum-ts-claude-sdk-hook-sentinel-${process.pid}`
+const proofRunId = process.env.EDICTUM_LIVE_PROOF_RUN_ID ?? String(process.pid)
+if (!/^[A-Za-z0-9_-]{1,64}$/.test(proofRunId)) {
+  console.error(
+    'EDICTUM_LIVE_PROOF_RUN_ID must contain 1-64 ASCII letters, digits, underscores, or hyphens',
+  )
+  process.exit(2)
+}
+const sentinel = `/tmp/edictum-ts-claude-sdk-hook-sentinel-${proofRunId}`
 const permissionOriginalSentinel = `/tmp/edictum-ts-claude-sdk-permission-original-${process.pid}`
 const postProbeFile = `/tmp/edictum-ts-claude-sdk-post-probe-${process.pid}`
 if (existsSync(sentinel)) {

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -56,7 +56,7 @@ function permissionBoundaryDenial(): {
   return {
     behavior: 'deny',
     message:
-      'DENIED: Edictum rejected an unsafe or invalid SDK permission result; updatedInput is not supported after PreToolUse governance',
+      'BLOCKED: Edictum rejected an unsafe or invalid SDK permission result; input and permission mutations are not supported after PreToolUse governance',
   }
 }
 
@@ -199,7 +199,7 @@ export class ClaudeAgentSDKAdapter {
           hookSpecificOutput: {
             hookEventName: 'PreToolUse',
             permissionDecision: 'deny',
-            permissionDecisionReason: 'DENIED: Claude Agent SDK supplied invalid tool input',
+            permissionDecisionReason: 'BLOCKED: Claude Agent SDK supplied invalid tool input',
           },
         }
       }
@@ -305,9 +305,10 @@ export class ClaudeAgentSDKAdapter {
   }
 
   /**
-   * Wrap an SDK permission callback so it cannot replace arguments after
-   * PreToolUse governance. Null is preserved for documented out-of-band
-   * responses. Throws and malformed results fail closed with a fixed denial.
+   * Wrap an SDK permission callback so it cannot mutate arguments or permissions
+   * after PreToolUse governance. Accepted decisions are copied into fresh plain
+   * objects. Null is preserved for documented out-of-band responses. Throws and
+   * malformed results fail closed with a fixed denial.
    */
   wrapCanUseTool(callback: CanUseTool): CanUseTool {
     return async (toolName, input, options) => {
@@ -321,17 +322,38 @@ export class ClaudeAgentSDKAdapter {
         }
 
         const permissionResult = result as Record<string, unknown>
+        const decisionClassification = permissionResult['decisionClassification']
+        if (
+          decisionClassification !== undefined &&
+          decisionClassification !== 'user_temporary' &&
+          decisionClassification !== 'user_permanent' &&
+          decisionClassification !== 'user_reject'
+        ) {
+          return permissionBoundaryDenial()
+        }
+
         if (permissionResult['behavior'] === 'allow') {
-          if ('updatedInput' in permissionResult) {
+          if ('updatedInput' in permissionResult || 'updatedPermissions' in permissionResult) {
             return permissionBoundaryDenial()
           }
-          return result as Awaited<ReturnType<CanUseTool>>
+          return decisionClassification === undefined
+            ? { behavior: 'allow' }
+            : { behavior: 'allow', decisionClassification }
         }
         if (
           permissionResult['behavior'] === 'deny' &&
           typeof permissionResult['message'] === 'string'
         ) {
-          return result as Awaited<ReturnType<CanUseTool>>
+          const interrupt = permissionResult['interrupt']
+          if (interrupt !== undefined && typeof interrupt !== 'boolean') {
+            return permissionBoundaryDenial()
+          }
+          return {
+            behavior: 'deny',
+            message: permissionResult['message'],
+            ...(interrupt === undefined ? {} : { interrupt }),
+            ...(decisionClassification === undefined ? {} : { decisionClassification }),
+          }
         }
         return permissionBoundaryDenial()
       } catch {

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -418,6 +418,8 @@ export class ClaudeAgentSDKAdapter {
    * Wrap an SDK permission callback so it cannot mutate arguments or permissions
    * after PreToolUse governance. If the tool input reaching this wrapper differs
    * from the pending governed args for that toolUseID, the call is blocked.
+   * The same check runs again after the permission callback returns, so a
+   * mutation of the SDK-owned input during the await cannot sneak through.
    * Accepted decisions are copied into fresh plain objects. Null is preserved
    * for documented out-of-band responses. Throws and malformed results fail
    * closed with a fixed block.
@@ -438,6 +440,14 @@ export class ClaudeAgentSDKAdapter {
         // already-governed arguments without using updatedInput (rejected below).
         const isolatedInput = structuredClone(input)
         const result: unknown = await callback(toolName, isolatedInput, options)
+        // Neighbor hooks can mutate the SDK-owned input while the callback
+        // is awaited. Re-check the object that will execute.
+        if (pending !== undefined) {
+          const inputStillMatches = pendingMatchesGovernedCall(pending, toolName, input)
+          if (!inputStillMatches) {
+            return permissionBoundaryDenial()
+          }
+        }
         if (result === null) {
           return null
         }

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -339,7 +339,8 @@ export class ClaudeAgentSDKAdapter {
           return permissionBoundaryDenial()
         }
 
-        if (permissionResult['behavior'] === 'allow') {
+        const behavior = permissionResult['behavior']
+        if (behavior === 'allow') {
           if ('updatedInput' in permissionResult || 'updatedPermissions' in permissionResult) {
             return permissionBoundaryDenial()
           }
@@ -347,10 +348,11 @@ export class ClaudeAgentSDKAdapter {
             ? { behavior: 'allow' }
             : { behavior: 'allow', decisionClassification }
         }
-        if (
-          permissionResult['behavior'] === 'deny' &&
-          typeof permissionResult['message'] === 'string'
-        ) {
+        if (behavior === 'deny') {
+          const message = permissionResult['message']
+          if (typeof message !== 'string') {
+            return permissionBoundaryDenial()
+          }
           const interrupt = permissionResult['interrupt']
           if (interrupt !== undefined && typeof interrupt !== 'boolean') {
             return permissionBoundaryDenial()
@@ -359,7 +361,7 @@ export class ClaudeAgentSDKAdapter {
           // forward updatedPermissions or any callback-owned prototype/Proxy.
           return {
             behavior: 'deny',
-            message: permissionResult['message'],
+            message,
             ...(interrupt === undefined ? {} : { interrupt }),
             ...(decisionClassification === undefined ? {} : { decisionClassification }),
           }

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -60,6 +60,84 @@ function permissionBoundaryDenial(): {
   }
 }
 
+const MAX_GOVERNED_INPUT_DEPTH = 64
+
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+/**
+ * Deep-compare the tool args that will execute against the governed snapshot.
+ * Throws on exotic or overly deep values so callers can fail closed.
+ */
+function governedInputEquals(left: unknown, right: unknown, depth = 0): boolean {
+  if (depth > MAX_GOVERNED_INPUT_DEPTH) {
+    throw new TypeError('BLOCKED: tool input exceeded compare depth')
+  }
+  if (Object.is(left, right)) {
+    return true
+  }
+  if (left == null || right == null) {
+    return false
+  }
+
+  const leftType = typeof left
+  if (leftType !== typeof right) {
+    return false
+  }
+  if (leftType !== 'object') {
+    return false
+  }
+
+  if (left instanceof Date || right instanceof Date) {
+    return left instanceof Date && right instanceof Date && left.getTime() === right.getTime()
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false
+    }
+    for (let i = 0; i < left.length; i += 1) {
+      if (!governedInputEquals(left[i], right[i], depth + 1)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  if (!isPlainObject(left) || !isPlainObject(right)) {
+    throw new TypeError('BLOCKED: governed input compare requires plain JSON-like values')
+  }
+
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+  const leftKeys = Object.keys(leftRecord)
+  const rightKeys = Object.keys(rightRecord)
+  if (leftKeys.length !== rightKeys.length) {
+    return false
+  }
+  for (const key of leftKeys) {
+    if (!Object.prototype.hasOwnProperty.call(rightRecord, key)) {
+      return false
+    }
+    if (!governedInputEquals(leftRecord[key], rightRecord[key], depth + 1)) {
+      return false
+    }
+  }
+  return true
+}
+
+function pendingMatchesGovernedCall(
+  pending: PendingCall,
+  toolName: string,
+  toolInput: unknown,
+): boolean {
+  return (
+    pending.toolCall.toolName === toolName && governedInputEquals(pending.toolCall.args, toolInput)
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Claude Agent SDK hook types
 // ---------------------------------------------------------------------------
@@ -208,6 +286,35 @@ export class ClaudeAgentSDKAdapter {
       }
 
       const callId = toolUseID ?? input.tool_use_id ?? randomUUID()
+      const pending = this._pending.get(callId)
+      if (pending !== undefined) {
+        let inputMatches = false
+        try {
+          inputMatches = pendingMatchesGovernedCall(pending, input.tool_name, input.tool_input)
+        } catch {
+          return {
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'deny',
+              permissionDecisionReason:
+                'BLOCKED: Edictum could not compare tool input against the governed snapshot',
+            },
+          }
+        }
+        if (!inputMatches) {
+          return {
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'deny',
+              permissionDecisionReason:
+                'BLOCKED: Edictum rejected a tool input replacement after PreToolUse governance',
+            },
+          }
+        }
+        // Same governed input: do not re-run _pre or emit a permission decision.
+        return {}
+      }
+
       const result = await this._pre(
         input.tool_name,
         input.tool_input as Record<string, unknown>,
@@ -309,13 +416,23 @@ export class ClaudeAgentSDKAdapter {
 
   /**
    * Wrap an SDK permission callback so it cannot mutate arguments or permissions
-   * after PreToolUse governance. Accepted decisions are copied into fresh plain
-   * objects. Null is preserved for documented out-of-band responses. Throws and
-   * malformed results fail closed with a fixed denial.
+   * after PreToolUse governance. If the tool input reaching this wrapper differs
+   * from the pending governed args for that toolUseID, the call is blocked.
+   * Accepted decisions are copied into fresh plain objects. Null is preserved
+   * for documented out-of-band responses. Throws and malformed results fail
+   * closed with a fixed block.
    */
   wrapCanUseTool(callback: CanUseTool): CanUseTool {
     return async (toolName, input, options) => {
       try {
+        const pending = this._pending.get(options.toolUseID)
+        if (pending !== undefined) {
+          const inputMatches = pendingMatchesGovernedCall(pending, toolName, input)
+          if (!inputMatches) {
+            return permissionBoundaryDenial()
+          }
+        }
+
         // The SDK-owned input may execute after this callback returns. Give the
         // callback a detached copy so in-place mutation cannot change the
         // already-governed arguments without using updatedInput (rejected below).

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -341,7 +341,11 @@ export class ClaudeAgentSDKAdapter {
 
         const behavior = permissionResult['behavior']
         if (behavior === 'allow') {
-          if ('updatedInput' in permissionResult || 'updatedPermissions' in permissionResult) {
+          if (
+            'updatedInput' in permissionResult ||
+            'updatedPermissions' in permissionResult ||
+            decisionClassification === 'user_reject'
+          ) {
             return permissionBoundaryDenial()
           }
           return decisionClassification === undefined

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -6,13 +6,22 @@
  *
  * Integration point: PreToolUse / PostToolUse hooks.
  *
- * Note: toSdkHooks() fully enforces preconditions. For postcondition
- * redact/deny, the adapter sets updatedMCPToolOutput in the PostToolUse
- * response, but full enforcement depends on the Claude Agent SDK honoring
- * this field. Use the wrapper integration path for guaranteed enforcement.
+ * Note: toSdkHooks() fully enforces preconditions. Postconditions run after
+ * the tool, so they cannot undo side effects. Native hook output replacement
+ * is not enforced: updatedToolOutput requires a schema-preserving replacement,
+ * which Edictum cannot safely synthesize from its generic postcondition result.
  */
 
 import { randomUUID } from 'node:crypto'
+
+import type {
+  HookCallback as SDKHookCallback,
+  HookCallbackMatcher,
+  PostToolUseHookInput as SDKPostToolUseHookInput,
+  PostToolUseHookSpecificOutput,
+  PreToolUseHookInput as SDKPreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from '@anthropic-ai/claude-agent-sdk'
 
 import {
   type AuditAction,
@@ -38,49 +47,15 @@ export const VERSION = '0.1.0' as const
 const MAX_WORKFLOW_APPROVAL_ROUNDS = 32
 
 // ---------------------------------------------------------------------------
-// Claude Agent SDK hook types (structural -- no framework import needed)
+// Claude Agent SDK hook types
 // ---------------------------------------------------------------------------
 
-/** Shape of input passed to a PreToolUse hook callback. */
-export interface PreToolUseInput {
-  readonly hook_event_name: string
-  readonly tool_name: string
-  readonly tool_input: Record<string, unknown>
-  readonly tool_use_id?: string
-}
-
-/** Shape of input passed to a PostToolUse hook callback. */
-export interface PostToolUseInput {
-  readonly hook_event_name: string
-  readonly tool_name: string
-  readonly tool_use_id?: string
-  readonly tool_response?: unknown
-  /** @deprecated Use tool_response instead. Kept for backward compatibility. */
-  readonly tool_result?: unknown
-}
-
-/** PreToolUse hook output for deny. */
-export interface PreToolUseHookOutput {
-  readonly hookSpecificOutput: {
-    readonly hookEventName: 'PreToolUse'
-    readonly permissionDecision: 'allow' | 'deny'
-    readonly permissionDecisionReason?: string
-  }
-}
-
-/** PostToolUse hook output (informational + optional result substitution). */
-export interface PostToolUseHookOutput {
-  readonly hookSpecificOutput?: {
-    readonly hookEventName: 'PostToolUse'
-    readonly additionalContext?: string
-    readonly updatedMCPToolOutput?: unknown
-  }
-}
-
-/** Hook callback type matching Claude Agent SDK convention. */
-export type HookCallback = (input: {
-  readonly input: PreToolUseInput | PostToolUseInput
-}) => Promise<PreToolUseHookOutput | PostToolUseHookOutput | Record<string, never>>
+export type HookCallback = SDKHookCallback
+export type HookMatcher = HookCallbackMatcher
+export type PreToolUseInput = SDKPreToolUseHookInput
+export type PostToolUseInput = SDKPostToolUseHookInput
+export type PreToolUseHookOutput = { hookSpecificOutput: PreToolUseHookSpecificOutput }
+export type PostToolUseHookOutput = { hookSpecificOutput?: PostToolUseHookSpecificOutput }
 
 // ---------------------------------------------------------------------------
 // ClaudeAgentSDKAdapterOptions
@@ -182,108 +157,97 @@ export class ClaudeAgentSDKAdapter {
    * ```ts
    * const adapter = new ClaudeAgentSDKAdapter(guard);
    * const hooks = adapter.toSdkHooks();
-   * // Pass hooks.PreToolUse and hooks.PostToolUse to Claude Agent SDK
+   * // Pass hooks as options.hooks to the Claude Agent SDK.
    * ```
    */
   toSdkHooks(options?: ToSdkHooksOptions): {
-    PreToolUse: HookCallback[]
-    PostToolUse: HookCallback[]
+    PreToolUse: HookCallbackMatcher[]
+    PostToolUse: HookCallbackMatcher[]
   } {
     this._onPostconditionWarn = options?.onPostconditionWarn ?? null
 
+    const preToolUse: SDKHookCallback = async (input, toolUseID) => {
+      if (input.hook_event_name !== 'PreToolUse') {
+        return {}
+      }
+
+      if (
+        typeof input.tool_input !== 'object' ||
+        input.tool_input == null ||
+        Array.isArray(input.tool_input)
+      ) {
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: 'DENIED: Claude Agent SDK supplied invalid tool input',
+          },
+        }
+      }
+
+      const callId = toolUseID ?? input.tool_use_id ?? randomUUID()
+      const result = await this._pre(
+        input.tool_name,
+        input.tool_input as Record<string, unknown>,
+        callId,
+      )
+
+      if (result != null) {
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: result,
+          },
+        }
+      }
+
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      }
+    }
+
+    const postToolUse: SDKHookCallback = async (input, toolUseID) => {
+      if (input.hook_event_name !== 'PostToolUse') {
+        return {}
+      }
+
+      const toolResponse = input.tool_response
+
+      // Correlate via the callback argument first, then the input field.
+      const callId = toolUseID ?? input.tool_use_id
+      if (!callId || !this._pending.has(callId)) {
+        return {}
+      }
+
+      const postResult = await this._post(callId, toolResponse)
+
+      const outputChanged = postResult.outputSuppressed || postResult.result !== toolResponse
+
+      if (postResult.violations.length > 0 || outputChanged) {
+        const findings = postResult.violations.map((finding) => finding.message)
+        if (outputChanged) {
+          findings.push(
+            'Edictum did not replace tool output: Claude Agent SDK updatedToolOutput requires a schema-preserving replacement that the generic adapter cannot synthesize',
+          )
+        }
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PostToolUse',
+            additionalContext: findings.join('\n'),
+          },
+        }
+      }
+
+      return {}
+    }
+
     return {
-      PreToolUse: [
-        async ({ input }): Promise<PreToolUseHookOutput> => {
-          const hookInput = input as PreToolUseInput
-          const toolName = hookInput.tool_name
-          const toolInput = hookInput.tool_input
-          const callId = hookInput.tool_use_id ?? randomUUID()
-
-          const result = await this._pre(toolName, toolInput, callId)
-
-          if (result != null) {
-            return {
-              hookSpecificOutput: {
-                hookEventName: 'PreToolUse',
-                permissionDecision: 'deny',
-                permissionDecisionReason: result,
-              },
-            }
-          }
-
-          return {
-            hookSpecificOutput: {
-              hookEventName: 'PreToolUse',
-              permissionDecision: 'allow',
-            },
-          }
-        },
-      ],
-      PostToolUse: [
-        async ({ input }): Promise<PostToolUseHookOutput | Record<string, never>> => {
-          const hookInput = input as PostToolUseInput
-          // Note 2: read tool_response (preferred), fall back to tool_result
-          const toolResponse =
-            hookInput.tool_response !== undefined ? hookInput.tool_response : hookInput.tool_result
-
-          // Correlate via tool_use_id (exact match), then tool_name (only if unambiguous)
-          let callId: string | undefined
-
-          // Note 2: use tool_use_id for correlation if available
-          if (hookInput.tool_use_id && this._pending.has(hookInput.tool_use_id)) {
-            callId = hookInput.tool_use_id
-          }
-
-          // Fall back to tool_name match — only if unambiguous (exactly one match)
-          if (!callId) {
-            const toolName = hookInput.tool_name
-            if (toolName) {
-              let matchCount = 0
-              let matchedId: string | undefined
-              for (const [id, pending] of this._pending) {
-                if (pending.toolCall.toolName === toolName) {
-                  matchCount++
-                  matchedId = id
-                }
-              }
-              if (matchCount === 1 && matchedId) {
-                callId = matchedId
-              }
-              // If matchCount > 1 or 0, callId stays undefined → passthrough
-            }
-          }
-
-          if (callId) {
-            const postResult = await this._post(callId, toolResponse)
-
-            // Note 3: return updatedMCPToolOutput for redacted/suppressed content
-            if (postResult.outputSuppressed || postResult.result !== toolResponse) {
-              return {
-                hookSpecificOutput: {
-                  hookEventName: 'PostToolUse',
-                  updatedMCPToolOutput: postResult.result,
-                  additionalContext:
-                    postResult.violations.length > 0
-                      ? postResult.violations.map((f) => f.message).join('\n')
-                      : undefined,
-                },
-              }
-            }
-
-            if (postResult.violations.length > 0) {
-              const context = postResult.violations.map((f) => f.message).join('\n')
-              return {
-                hookSpecificOutput: {
-                  hookEventName: 'PostToolUse',
-                  additionalContext: context,
-                },
-              }
-            }
-          }
-
-          return {}
-        },
-      ],
+      PreToolUse: [{ hooks: [preToolUse] }],
+      PostToolUse: [{ hooks: [postToolUse] }],
     }
   }
 

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -322,7 +322,7 @@ export class ClaudeAgentSDKAdapter {
 
         const permissionResult = result as Record<string, unknown>
         if (permissionResult['behavior'] === 'allow') {
-          if (Object.prototype.hasOwnProperty.call(permissionResult, 'updatedInput')) {
+          if ('updatedInput' in permissionResult) {
             return permissionBoundaryDenial()
           }
           return result as Awaited<ReturnType<CanUseTool>>

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -331,6 +331,37 @@ export class ClaudeAgentSDKAdapter {
         }
       }
 
+      // _pre stored a deep copy. The SDK-owned tool_input can still change
+      // while that await is in flight. Recheck the live object before {}.
+      const stored = this._pending.get(callId)
+      let inputStillMatches = false
+      try {
+        inputStillMatches =
+          stored !== undefined &&
+          pendingMatchesGovernedCall(stored, input.tool_name, input.tool_input)
+      } catch {
+        this._pending.delete(callId)
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason:
+              'BLOCKED: Edictum could not compare tool input against the governed snapshot',
+          },
+        }
+      }
+      if (!inputStillMatches) {
+        this._pending.delete(callId)
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason:
+              'BLOCKED: Edictum rejected a tool input replacement after PreToolUse governance',
+          },
+        }
+      }
+
       // Passing Edictum is not permission approval. Return no decision so the
       // SDK still applies allowedTools, canUseTool, and its normal prompt path.
       return {}

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -15,6 +15,7 @@
 import { randomUUID } from 'node:crypto'
 
 import type {
+  CanUseTool,
   HookCallback as SDKHookCallback,
   HookCallbackMatcher,
   PostToolUseFailureHookInput as SDKPostToolUseFailureHookInput,
@@ -47,6 +48,17 @@ import {
 
 export const VERSION = '0.3.0' as const
 const MAX_WORKFLOW_APPROVAL_ROUNDS = 32
+
+function permissionBoundaryDenial(): {
+  behavior: 'deny'
+  message: string
+} {
+  return {
+    behavior: 'deny',
+    message:
+      'DENIED: Edictum rejected an unsafe or invalid SDK permission result; updatedInput is not supported after PreToolUse governance',
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Claude Agent SDK hook types
@@ -230,13 +242,13 @@ export class ClaudeAgentSDKAdapter {
     const postContext = (postResult: PostCallResult, toolResponse: unknown): string | null => {
       const outputChanged = postResult.outputSuppressed || postResult.result !== toolResponse
       if (postResult.violations.length > 0 || outputChanged) {
-        const findings = postResult.violations.map((finding) => finding.message)
+        const violations = postResult.violations.map((violation) => violation.message)
         if (outputChanged) {
-          findings.push(
+          violations.push(
             'Edictum did not replace tool output: Claude Agent SDK updatedToolOutput requires a schema-preserving replacement that the generic adapter cannot synthesize',
           )
         }
-        return findings.join('\n')
+        return violations.join('\n')
       }
       return null
     }
@@ -289,6 +301,42 @@ export class ClaudeAgentSDKAdapter {
       PreToolUse: [{ hooks: [preToolUse] }],
       PostToolUse: [{ hooks: [postToolUse] }],
       PostToolUseFailure: [{ hooks: [postToolUseFailure] }],
+    }
+  }
+
+  /**
+   * Wrap an SDK permission callback so it cannot replace arguments after
+   * PreToolUse governance. Null is preserved for documented out-of-band
+   * responses. Throws and malformed results fail closed with a fixed denial.
+   */
+  wrapCanUseTool(callback: CanUseTool): CanUseTool {
+    return async (toolName, input, options) => {
+      try {
+        const result: unknown = await callback(toolName, input, options)
+        if (result === null) {
+          return null
+        }
+        if (typeof result !== 'object') {
+          return permissionBoundaryDenial()
+        }
+
+        const permissionResult = result as Record<string, unknown>
+        if (permissionResult['behavior'] === 'allow') {
+          if (Object.prototype.hasOwnProperty.call(permissionResult, 'updatedInput')) {
+            return permissionBoundaryDenial()
+          }
+          return result as Awaited<ReturnType<CanUseTool>>
+        }
+        if (
+          permissionResult['behavior'] === 'deny' &&
+          typeof permissionResult['message'] === 'string'
+        ) {
+          return result as Awaited<ReturnType<CanUseTool>>
+        }
+        return permissionBoundaryDenial()
+      } catch {
+        return permissionBoundaryDenial()
+      }
     }
   }
 

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -4,7 +4,7 @@
  * Translates Edictum pipeline decisions into Claude Agent SDK hook format.
  * The adapter does NOT contain governance logic -- that lives in CheckPipeline.
  *
- * Integration point: PreToolUse / PostToolUse hooks.
+ * Integration point: PreToolUse / PostToolUse / PostToolUseFailure hooks.
  *
  * Note: toSdkHooks() fully enforces preconditions. Postconditions run after
  * the tool, so they cannot undo side effects. Native hook output replacement
@@ -17,6 +17,8 @@ import { randomUUID } from 'node:crypto'
 import type {
   HookCallback as SDKHookCallback,
   HookCallbackMatcher,
+  PostToolUseFailureHookInput as SDKPostToolUseFailureHookInput,
+  PostToolUseFailureHookSpecificOutput,
   PostToolUseHookInput as SDKPostToolUseHookInput,
   PostToolUseHookSpecificOutput,
   PreToolUseHookInput as SDKPreToolUseHookInput,
@@ -54,8 +56,12 @@ export type HookCallback = SDKHookCallback
 export type HookMatcher = HookCallbackMatcher
 export type PreToolUseInput = SDKPreToolUseHookInput
 export type PostToolUseInput = SDKPostToolUseHookInput
+export type PostToolUseFailureInput = SDKPostToolUseFailureHookInput
 export type PreToolUseHookOutput = { hookSpecificOutput: PreToolUseHookSpecificOutput }
 export type PostToolUseHookOutput = { hookSpecificOutput?: PostToolUseHookSpecificOutput }
+export type PostToolUseFailureHookOutput = {
+  hookSpecificOutput?: PostToolUseFailureHookSpecificOutput
+}
 
 // ---------------------------------------------------------------------------
 // ClaudeAgentSDKAdapterOptions
@@ -96,7 +102,7 @@ interface PendingCall {
  * The adapter does NOT contain governance logic -- that lives in
  * CheckPipeline. The adapter only:
  * 1. Creates envelopes from SDK hook data
- * 2. Manages pending state (toolCall) between PreToolUse/PostToolUse
+ * 2. Manages pending state between PreToolUse and either post-tool exit event
  * 3. Translates PreDecision/PostDecision into hook behavior
  * 4. Handles observe mode (deny -> allow conversion)
  */
@@ -163,6 +169,7 @@ export class ClaudeAgentSDKAdapter {
   toSdkHooks(options?: ToSdkHooksOptions): {
     PreToolUse: HookCallbackMatcher[]
     PostToolUse: HookCallbackMatcher[]
+    PostToolUseFailure: HookCallbackMatcher[]
   } {
     this._onPostconditionWarn = options?.onPostconditionWarn ?? null
 
@@ -210,23 +217,21 @@ export class ClaudeAgentSDKAdapter {
       }
     }
 
-    const postToolUse: SDKHookCallback = async (input, toolUseID) => {
-      if (input.hook_event_name !== 'PostToolUse') {
-        return {}
-      }
-
-      const toolResponse = input.tool_response
-
-      // Correlate via the callback argument first, then the input field.
-      const callId = toolUseID ?? input.tool_use_id
+    const finalizePending = async (
+      toolUseID: string | undefined,
+      inputToolUseID: string,
+      toolResponse: unknown,
+      forcedToolSuccess?: boolean,
+    ): Promise<PostCallResult | null> => {
+      const callId = toolUseID ?? inputToolUseID
       if (!callId || !this._pending.has(callId)) {
-        return {}
+        return null
       }
+      return this._post(callId, toolResponse, forcedToolSuccess)
+    }
 
-      const postResult = await this._post(callId, toolResponse)
-
+    const postContext = (postResult: PostCallResult, toolResponse: unknown): string | null => {
       const outputChanged = postResult.outputSuppressed || postResult.result !== toolResponse
-
       if (postResult.violations.length > 0 || outputChanged) {
         const findings = postResult.violations.map((finding) => finding.message)
         if (outputChanged) {
@@ -234,10 +239,27 @@ export class ClaudeAgentSDKAdapter {
             'Edictum did not replace tool output: Claude Agent SDK updatedToolOutput requires a schema-preserving replacement that the generic adapter cannot synthesize',
           )
         }
+        return findings.join('\n')
+      }
+      return null
+    }
+
+    const postToolUse: SDKHookCallback = async (input, toolUseID) => {
+      if (input.hook_event_name !== 'PostToolUse') {
+        return {}
+      }
+
+      const postResult = await finalizePending(toolUseID, input.tool_use_id, input.tool_response)
+      if (!postResult) {
+        return {}
+      }
+
+      const additionalContext = postContext(postResult, input.tool_response)
+      if (additionalContext) {
         return {
           hookSpecificOutput: {
             hookEventName: 'PostToolUse',
-            additionalContext: findings.join('\n'),
+            additionalContext,
           },
         }
       }
@@ -245,9 +267,31 @@ export class ClaudeAgentSDKAdapter {
       return {}
     }
 
+    const postToolUseFailure: SDKHookCallback = async (input, toolUseID) => {
+      if (input.hook_event_name !== 'PostToolUseFailure') {
+        return {}
+      }
+
+      const failureResponse = {
+        is_error: true,
+        error: input.error,
+        is_interrupt: input.is_interrupt === true,
+      }
+      const postResult = await finalizePending(toolUseID, input.tool_use_id, failureResponse, false)
+      if (!postResult) {
+        return {}
+      }
+
+      const additionalContext = postContext(postResult, failureResponse)
+      return additionalContext
+        ? { hookSpecificOutput: { hookEventName: 'PostToolUseFailure', additionalContext } }
+        : {}
+    }
+
     return {
       PreToolUse: [{ hooks: [preToolUse] }],
       PostToolUse: [{ hooks: [postToolUse] }],
+      PostToolUseFailure: [{ hooks: [postToolUseFailure] }],
     }
   }
 
@@ -496,9 +540,19 @@ export class ClaudeAgentSDKAdapter {
   /**
    * Run post-execution governance. Returns PostCallResult with violations.
    *
+   * Finalization is at-most-once: pending state is consumed before calling
+   * postconditions, workflow storage, session storage, or the audit sink. Those
+   * ports do not share a transaction or idempotency key, so retrying after a
+   * partial failure could duplicate durable state. A thrown finalization error
+   * is propagated and is not retried by this adapter.
+   *
    * Exposed for direct testing without framework imports.
    */
-  async _post(callId: string, toolResponse: unknown = undefined): Promise<PostCallResult> {
+  async _post(
+    callId: string,
+    toolResponse: unknown = undefined,
+    forcedToolSuccess?: boolean,
+  ): Promise<PostCallResult> {
     const pending = this._pending.get(callId)
     this._pending.delete(callId)
 
@@ -508,8 +562,8 @@ export class ClaudeAgentSDKAdapter {
 
     const { toolCall, workflowStageId, workflowInvolved } = pending
 
-    // Derive tool_success from response
-    const toolSuccess = this._checkToolSuccess(toolCall.toolName, toolResponse)
+    // An SDK failure event is authoritative; otherwise derive success from the configured check.
+    const toolSuccess = forcedToolSuccess ?? this._checkToolSuccess(toolCall.toolName, toolResponse)
 
     // Run pipeline
     const postDecision = await this._pipeline.postExecute(toolCall, toolResponse, toolSuccess)

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -177,6 +177,9 @@ export class ClaudeAgentSDKAdapter {
    * const hooks = adapter.toSdkHooks();
    * // Pass hooks as options.hooks to the Claude Agent SDK.
    * ```
+   *
+   * Calling this method again replaces the postcondition warning callback for
+   * every hook set returned by this adapter instance.
    */
   toSdkHooks(options?: ToSdkHooksOptions): {
     PreToolUse: HookCallbackMatcher[]
@@ -313,7 +316,11 @@ export class ClaudeAgentSDKAdapter {
   wrapCanUseTool(callback: CanUseTool): CanUseTool {
     return async (toolName, input, options) => {
       try {
-        const result: unknown = await callback(toolName, input, options)
+        // The SDK-owned input may execute after this callback returns. Give the
+        // callback a detached copy so in-place mutation cannot change the
+        // already-governed arguments without using updatedInput (rejected below).
+        const isolatedInput = structuredClone(input)
+        const result: unknown = await callback(toolName, isolatedInput, options)
         if (result === null) {
           return null
         }
@@ -348,6 +355,8 @@ export class ClaudeAgentSDKAdapter {
           if (interrupt !== undefined && typeof interrupt !== 'boolean') {
             return permissionBoundaryDenial()
           }
+          // Construct from an explicit allowlist. In particular, do not
+          // forward updatedPermissions or any callback-owned prototype/Proxy.
           return {
             behavior: 'deny',
             message: permissionResult['message'],

--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -45,7 +45,7 @@ import {
   defaultSuccessCheck,
 } from '@edictum/core'
 
-export const VERSION = '0.1.0' as const
+export const VERSION = '0.3.0' as const
 const MAX_WORKFLOW_APPROVAL_ROUNDS = 32
 
 // ---------------------------------------------------------------------------
@@ -209,12 +209,9 @@ export class ClaudeAgentSDKAdapter {
         }
       }
 
-      return {
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-        },
-      }
+      // Passing Edictum is not permission approval. Return no decision so the
+      // SDK still applies allowedTools, canUseTool, and its normal prompt path.
+      return {}
     }
 
     const finalizePending = async (

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -914,11 +914,12 @@ describe('toSdkHooks', () => {
   it('isolates SDK-owned input from in-place canUseTool mutations', async () => {
     const adapter = new ClaudeAgentSDKAdapter(makeGuard())
     const sdkInput = { command: 'touch /tmp/allowed', nested: { path: '/tmp/allowed' } }
-    const wrapped = adapter.wrapCanUseTool(async (_toolName, input) => {
+    const callback = vi.fn(async (_toolName: string, input: Record<string, unknown>) => {
       input['command'] = 'touch /tmp/blocked'
       ;(input['nested'] as Record<string, unknown>)['path'] = '/tmp/blocked'
-      return { behavior: 'allow' }
+      return { behavior: 'allow' as const }
     })
+    const wrapped = adapter.wrapCanUseTool(callback)
 
     const result = await wrapped('Bash', sdkInput, {
       signal: new AbortController().signal,
@@ -930,10 +931,41 @@ describe('toSdkHooks', () => {
     })
 
     expect(result).toEqual({ behavior: 'allow' })
+    expect(callback).toHaveBeenCalledOnce()
     expect(sdkInput).toEqual({
       command: 'touch /tmp/allowed',
       nested: { path: '/tmp/allowed' },
     })
+  })
+
+  it('passes the SDK interrupt flag to failure postconditions', async () => {
+    const observedResponses: unknown[] = []
+    const guard = makeGuard({
+      rules: [
+        {
+          tool: 'Bash',
+          contractType: 'post',
+          check: async (_toolCall, response) => {
+            observedResponses.push(response)
+            return Decision.pass_()
+          },
+        } satisfies Postcondition,
+      ],
+      tools: { Bash: { side_effect: 'execute' } },
+    })
+    const adapter = new ClaudeAgentSDKAdapter(guard)
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+
+    await sdkCallback(options, 'PreToolUse')(preInput('Bash', {}), 'call-1', hookContext)
+    await sdkCallback(options, 'PostToolUseFailure')(
+      { ...failureInput('Bash', 'interrupted'), is_interrupt: true },
+      'call-1',
+      hookContext,
+    )
+
+    expect(observedResponses).toEqual([
+      { is_error: true, error: 'interrupted', is_interrupt: true },
+    ])
   })
 })
 

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -574,27 +574,29 @@ describe('toSdkHooks', () => {
 
   it('rejects permission callbacks that replace governed input', async () => {
     const adapter = new ClaudeAgentSDKAdapter(makeGuard())
-    const callback = adapter.wrapCanUseTool(async () => ({
+    const ownReplacement = adapter.wrapCanUseTool(async () => ({
       behavior: 'allow',
       updatedInput: { command: 'touch /tmp/rewritten' },
     }))
+    const inheritedReplacement = adapter.wrapCanUseTool(
+      async () =>
+        Object.assign(Object.create({ updatedInput: { command: 'touch /tmp/inherited' } }), {
+          behavior: 'allow' as const,
+        }) as { behavior: 'allow' },
+    )
+    const args = [
+      'Bash',
+      { command: 'echo safe' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    ] as const
 
-    await expect(
-      callback(
-        'Bash',
-        { command: 'echo safe' },
-        {
-          signal: hookContext.signal,
-          toolUseID: 'call-1',
-          requestId: 'request-1',
-        },
-      ),
-    ).resolves.toEqual(
+    await expect(ownReplacement(...args)).resolves.toEqual(
       expect.objectContaining({
         behavior: 'deny',
         message: expect.stringContaining('updatedInput is not supported'),
       }),
     )
+    await expect(inheritedReplacement(...args)).resolves.toMatchObject({ behavior: 'deny' })
   })
 
   it('fails closed on thrown and malformed permission results', async () => {

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -780,6 +780,22 @@ describe('toSdkHooks', () => {
     expect(result.hookSpecificOutput.permissionDecisionReason).toContain('BLOCKED')
   })
 
+  it('blocks PreToolUse when tool_input mutates while _pre is awaited', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+    const toolInput = { command: 'echo safe' }
+    const pending = sdkCallback(options, 'PreToolUse')(
+      preInput('Bash', toolInput),
+      'call-1',
+      hookContext,
+    )
+    toolInput.command = 'touch /tmp/mutated-during-pre'
+    const result = (await pending) as PreToolUseHookOutput
+
+    expect(result.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(result.hookSpecificOutput.permissionDecisionReason).toContain('BLOCKED')
+  })
+
   it('PreToolUse hook returns no permission decision for passing rules', async () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -735,6 +735,29 @@ describe('toSdkHooks', () => {
     )
   })
 
+  it('blocks wrapCanUseTool when SDK input mutates while the callback is awaited', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    await adapter._pre('Bash', { command: 'echo safe' }, 'call-1')
+    const input = { command: 'echo safe' }
+    const wrapped = adapter.wrapCanUseTool(async () => {
+      input.command = 'touch /tmp/mutated-during-await'
+      return { behavior: 'allow' }
+    })
+
+    await expect(
+      wrapped('Bash', input, {
+        signal: hookContext.signal,
+        toolUseID: 'call-1',
+        requestId: 'request-1',
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        behavior: 'deny',
+        message: expect.stringContaining('BLOCKED'),
+      }),
+    )
+  })
+
   it('blocks PreToolUse when tool_input is a replacement for a pending call', async () => {
     const adapter = new ClaudeAgentSDKAdapter(makeGuard())
     const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type {
   HookCallback,
   Options,
+  PostToolUseFailureHookInput,
   PostToolUseHookInput,
   PreToolUseHookInput,
 } from '@anthropic-ai/claude-agent-sdk'
@@ -73,7 +74,27 @@ function postInput(
   }
 }
 
-function sdkCallback(options: Pick<Options, 'hooks'>, event: 'PreToolUse' | 'PostToolUse') {
+function failureInput(
+  toolName: string,
+  error: string,
+  toolUseId = 'call-1',
+): PostToolUseFailureHookInput {
+  return {
+    session_id: 'test-session',
+    transcript_path: '/tmp/edictum-test-transcript',
+    cwd: '/tmp',
+    hook_event_name: 'PostToolUseFailure',
+    tool_name: toolName,
+    tool_input: {},
+    tool_use_id: toolUseId,
+    error,
+  }
+}
+
+function sdkCallback(
+  options: Pick<Options, 'hooks'>,
+  event: 'PreToolUse' | 'PostToolUse' | 'PostToolUseFailure',
+) {
   return options.hooks?.[event]?.[0]?.hooks[0] as HookCallback
 }
 
@@ -545,8 +566,10 @@ describe('toSdkHooks', () => {
 
     expect(options.hooks.PreToolUse).toHaveLength(1)
     expect(options.hooks.PostToolUse).toHaveLength(1)
+    expect(options.hooks.PostToolUseFailure).toHaveLength(1)
     expect(options.hooks.PreToolUse[0]).toEqual({ hooks: [expect.any(Function)] })
     expect(options.hooks.PostToolUse[0]).toEqual({ hooks: [expect.any(Function)] })
+    expect(options.hooks.PostToolUseFailure[0]).toEqual({ hooks: [expect.any(Function)] })
   })
 
   it('PreToolUse hook returns allow for passing rules', async () => {
@@ -732,6 +755,49 @@ describe('toSdkHooks', () => {
     )) as { hookSpecificOutput?: { additionalContext?: string } }
 
     expect(result.hookSpecificOutput?.additionalContext).toContain('postcondition ran')
+  })
+
+  it('finalizes failed tool calls through PostToolUseFailure exactly once', async () => {
+    const postContract: Postcondition = {
+      tool: '*',
+      contractType: 'post',
+      check: async () => Decision.fail('failure postcondition ran'),
+    }
+    const sink = makeSink()
+    const onPostconditionWarn = vi.fn()
+    const guard = makeGuard({
+      rules: [postContract],
+      auditSink: sink,
+      tools: { Bash: { side_effect: 'execute' } },
+      successCheck: () => true,
+    })
+    const adapter = new ClaudeAgentSDKAdapter(guard)
+    const options = {
+      hooks: adapter.toSdkHooks({ onPostconditionWarn }),
+    } satisfies Pick<Options, 'hooks'>
+
+    await sdkCallback(options, 'PreToolUse')(preInput('Bash', {}), 'call-1', hookContext)
+    const first = await sdkCallback(options, 'PostToolUseFailure')(
+      failureInput('Bash', 'command exited unsuccessfully'),
+      'call-1',
+      hookContext,
+    )
+    const duplicate = await sdkCallback(options, 'PostToolUseFailure')(
+      failureInput('Bash', 'duplicate delivery'),
+      'call-1',
+      hookContext,
+    )
+
+    expect(first).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUseFailure',
+        additionalContext: 'failure postcondition ran',
+      },
+    })
+    expect(duplicate).toEqual({})
+    expect(sink.filter(AuditAction.CALL_FAILED)).toHaveLength(1)
+    expect(sink.filter(AuditAction.CALL_EXECUTED)).toHaveLength(0)
+    expect(onPostconditionWarn).toHaveBeenCalledOnce()
   })
 })
 

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -7,6 +7,12 @@
  */
 
 import { describe, expect, it, vi } from 'vitest'
+import type {
+  HookCallback,
+  Options,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk'
 import {
   AuditAction,
   CollectingAuditSink,
@@ -30,6 +36,45 @@ function makeSink(): CollectingAuditSink {
 
 function makeGuard(options: ConstructorParameters<typeof Edictum>[0] = {}): Edictum {
   return new Edictum(options)
+}
+
+const hookContext = { signal: new AbortController().signal }
+
+function preInput(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  toolUseId = 'call-1',
+): PreToolUseHookInput {
+  return {
+    session_id: 'test-session',
+    transcript_path: '/tmp/edictum-test-transcript',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: toolName,
+    tool_input: toolInput,
+    tool_use_id: toolUseId,
+  }
+}
+
+function postInput(
+  toolName: string,
+  toolResponse: unknown,
+  toolUseId = 'call-1',
+): PostToolUseHookInput {
+  return {
+    session_id: 'test-session',
+    transcript_path: '/tmp/edictum-test-transcript',
+    cwd: '/tmp',
+    hook_event_name: 'PostToolUse',
+    tool_name: toolName,
+    tool_input: {},
+    tool_response: toolResponse,
+    tool_use_id: toolUseId,
+  }
+}
+
+function sdkCallback(options: Pick<Options, 'hooks'>, event: 'PreToolUse' | 'PostToolUse') {
+  return options.hooks?.[event]?.[0]?.hooks[0] as HookCallback
 }
 
 // ---------------------------------------------------------------------------
@@ -493,29 +538,27 @@ describe('_post edge cases', () => {
 // ---------------------------------------------------------------------------
 
 describe('toSdkHooks', () => {
-  it('returns correct structure with PreToolUse and PostToolUse arrays', () => {
+  it('hands SDK-native matcher objects to the Claude Agent SDK options contract', () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    expect(hooks.PreToolUse).toHaveLength(1)
-    expect(hooks.PostToolUse).toHaveLength(1)
-    expect(typeof hooks.PreToolUse[0]).toBe('function')
-    expect(typeof hooks.PostToolUse[0]).toBe('function')
+    expect(options.hooks.PreToolUse).toHaveLength(1)
+    expect(options.hooks.PostToolUse).toHaveLength(1)
+    expect(options.hooks.PreToolUse[0]).toEqual({ hooks: [expect.any(Function)] })
+    expect(options.hooks.PostToolUse[0]).toEqual({ hooks: [expect.any(Function)] })
   })
 
   it('PreToolUse hook returns allow for passing rules', async () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    const result = await hooks.PreToolUse[0]!({
-      input: {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'MyTool',
-        tool_input: {},
-      },
-    })
+    const result = await sdkCallback(options, 'PreToolUse')(
+      preInput('MyTool', {}),
+      'call-1',
+      hookContext,
+    )
 
     expect(result).toEqual({
       hookSpecificOutput: {
@@ -532,15 +575,13 @@ describe('toSdkHooks', () => {
     }
     const guard = makeGuard({ rules: [alwaysDeny] })
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    const result = await hooks.PreToolUse[0]!({
-      input: {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'MyTool',
-        tool_input: {},
-      },
-    })
+    const result = await sdkCallback(options, 'PreToolUse')(
+      preInput('MyTool', {}),
+      'call-1',
+      hookContext,
+    )
 
     expect(result).toEqual({
       hookSpecificOutput: {
@@ -554,24 +595,15 @@ describe('toSdkHooks', () => {
   it('PostToolUse hook returns empty object when no postconditions', async () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    // First trigger pre to create pending state
-    await hooks.PreToolUse[0]!({
-      input: {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'MyTool',
-        tool_input: {},
-      },
-    })
+    await sdkCallback(options, 'PreToolUse')(preInput('MyTool', {}), 'call-1', hookContext)
 
-    const result = await hooks.PostToolUse[0]!({
-      input: {
-        hook_event_name: 'PostToolUse',
-        tool_name: 'MyTool',
-        tool_result: 'success',
-      },
-    })
+    const result = await sdkCallback(options, 'PostToolUse')(
+      postInput('MyTool', 'success'),
+      'call-1',
+      hookContext,
+    )
 
     expect(result).toEqual({})
   })
@@ -592,66 +624,82 @@ describe('toSdkHooks', () => {
       tools: { MyTool: { side_effect: 'pure' } },
     })
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    await hooks.PreToolUse[0]!({
-      input: {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'MyTool',
-        tool_input: {},
-      },
-    })
+    await sdkCallback(options, 'PreToolUse')(preInput('MyTool', {}), 'call-1', hookContext)
 
-    const result = (await hooks.PostToolUse[0]!({
-      input: {
-        hook_event_name: 'PostToolUse',
-        tool_name: 'MyTool',
-        tool_result: 'the secret is here',
-      },
-    })) as { hookSpecificOutput?: { additionalContext?: string } }
+    const result = (await sdkCallback(options, 'PostToolUse')(
+      postInput('MyTool', 'the secret is here'),
+      'call-1',
+      hookContext,
+    )) as { hookSpecificOutput?: { additionalContext?: string } }
 
     expect(result.hookSpecificOutput?.additionalContext).toContain('Contains secret data')
   })
-})
 
-// ---------------------------------------------------------------------------
-// Ambiguous same-name call correlation (Violation #9)
-// ---------------------------------------------------------------------------
-
-describe('ambiguous same-name call correlation', () => {
-  it('skips postcondition when two same-name calls pending and no tool_use_id', async () => {
-    const postContract: Postcondition = {
+  it('does not claim suppression for tool output without a schema-preserving replacement', async () => {
+    const denyOutput = {
+      _edictum_type: 'postcondition',
+      type: 'postcondition',
+      name: 'suppress_test',
       tool: '*',
-      contractType: 'post',
-      check: async () => Decision.fail('should not run'),
+      effect: 'deny',
+      check: async () => Decision.fail('sensitive data detected'),
     }
-    const sink = makeSink()
-    const guard = makeGuard({ rules: [postContract], auditSink: sink })
+    const guard = makeGuard({
+      rules: [denyOutput as unknown as Postcondition],
+      tools: { Read: { side_effect: 'read' } },
+    })
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    // Two Read calls pending
-    await hooks.PreToolUse[0]!({
-      input: { hook_event_name: 'PreToolUse', tool_name: 'Read', tool_input: { path: '/a' } },
-    })
-    await hooks.PreToolUse[0]!({
-      input: { hook_event_name: 'PreToolUse', tool_name: 'Read', tool_input: { path: '/b' } },
-    })
+    await sdkCallback(options, 'PreToolUse')(preInput('Read', {}), 'call-1', hookContext)
+    const result = (await sdkCallback(options, 'PostToolUse')(
+      postInput('Read', { file: { content: 'sensitive data' }, type: 'text' }),
+      'call-1',
+      hookContext,
+    )) as { hookSpecificOutput?: { additionalContext?: string; updatedToolOutput?: unknown } }
 
-    // PostToolUse without tool_use_id — ambiguous, should passthrough
-    const result = await hooks.PostToolUse[0]!({
-      input: {
-        hook_event_name: 'PostToolUse',
-        tool_name: 'Read',
-        tool_response: 'file contents',
-      },
-    })
-
-    // Passthrough: empty object (no postcondition evaluation)
-    expect(result).toEqual({})
+    expect(result.hookSpecificOutput?.updatedToolOutput).toBeUndefined()
+    expect(result.hookSpecificOutput?.additionalContext).toContain(
+      'updatedToolOutput requires a schema-preserving replacement',
+    )
   })
 
-  it('correlates correctly when only one same-name call pending', async () => {
+  it('does not claim suppression for MCP tool output without its result schema', async () => {
+    const denyOutput = {
+      _edictum_type: 'postcondition',
+      type: 'postcondition',
+      name: 'suppress_test',
+      tool: '*',
+      effect: 'deny',
+      check: async () => Decision.fail('sensitive data detected'),
+    }
+    const guard = makeGuard({
+      rules: [denyOutput as unknown as Postcondition],
+      tools: { mcp__server__tool: { side_effect: 'read' } },
+    })
+    const adapter = new ClaudeAgentSDKAdapter(guard)
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+
+    await sdkCallback(options, 'PreToolUse')(
+      preInput('mcp__server__tool', {}),
+      'call-1',
+      hookContext,
+    )
+    const result = (await sdkCallback(options, 'PostToolUse')(
+      postInput('mcp__server__tool', 'sensitive data'),
+      'call-1',
+      hookContext,
+    )) as { hookSpecificOutput?: { additionalContext?: string; updatedToolOutput?: unknown } }
+
+    expect(result.hookSpecificOutput?.updatedToolOutput).toBeUndefined()
+    expect(result.hookSpecificOutput?.additionalContext).toContain(
+      'updatedToolOutput requires a schema-preserving replacement',
+    )
+  })
+
+  it('correlates concurrent same-name calls with the SDK toolUseID callback argument', async () => {
     const postContract: Postcondition = {
       tool: '*',
       contractType: 'post',
@@ -664,68 +712,24 @@ describe('ambiguous same-name call correlation', () => {
       tools: { Read: { side_effect: 'pure' } },
     })
     const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    // Only one Read call pending
-    await hooks.PreToolUse[0]!({
-      input: { hook_event_name: 'PreToolUse', tool_name: 'Read', tool_input: { path: '/a' } },
-    })
+    await sdkCallback(options, 'PreToolUse')(
+      preInput('Read', { path: '/a' }, 'input-id-is-ignored'),
+      'id-1',
+      hookContext,
+    )
+    await sdkCallback(options, 'PreToolUse')(
+      preInput('Read', { path: '/b' }, 'another-input-id'),
+      'id-2',
+      hookContext,
+    )
 
-    // PostToolUse without tool_use_id — unambiguous, should correlate
-    const result = (await hooks.PostToolUse[0]!({
-      input: {
-        hook_event_name: 'PostToolUse',
-        tool_name: 'Read',
-        tool_response: 'file contents',
-      },
-    })) as { hookSpecificOutput?: { additionalContext?: string } }
-
-    // Postcondition ran and produced violations
-    expect(result.hookSpecificOutput?.additionalContext).toContain('postcondition ran')
-  })
-
-  it('correlates correctly with explicit tool_use_id even when ambiguous', async () => {
-    const postContract: Postcondition = {
-      tool: '*',
-      contractType: 'post',
-      check: async () => Decision.fail('postcondition ran'),
-    }
-    const sink = makeSink()
-    const guard = makeGuard({
-      rules: [postContract],
-      auditSink: sink,
-      tools: { Read: { side_effect: 'pure' } },
-    })
-    const adapter = new ClaudeAgentSDKAdapter(guard)
-    const hooks = adapter.toSdkHooks()
-
-    // Two Read calls with explicit IDs
-    await hooks.PreToolUse[0]!({
-      input: {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { path: '/a' },
-        tool_use_id: 'id-1',
-      },
-    })
-    await hooks.PreToolUse[0]!({
-      input: {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { path: '/b' },
-        tool_use_id: 'id-2',
-      },
-    })
-
-    // PostToolUse WITH explicit tool_use_id → should correlate correctly
-    const result = (await hooks.PostToolUse[0]!({
-      input: {
-        hook_event_name: 'PostToolUse',
-        tool_name: 'Read',
-        tool_use_id: 'id-2',
-        tool_response: 'file contents',
-      },
-    })) as { hookSpecificOutput?: { additionalContext?: string } }
+    const result = (await sdkCallback(options, 'PostToolUse')(
+      postInput('Read', 'file contents', 'wrong-input-id'),
+      'id-2',
+      hookContext,
+    )) as { hookSpecificOutput?: { additionalContext?: string } }
 
     expect(result.hookSpecificOutput?.additionalContext).toContain('postcondition ran')
   })

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -910,6 +910,31 @@ describe('toSdkHooks', () => {
     expect(sink.filter(AuditAction.CALL_FAILED)).toHaveLength(1)
     expect(sink.filter(AuditAction.CALL_EXECUTED)).toHaveLength(0)
   })
+
+  it('isolates SDK-owned input from in-place canUseTool mutations', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const sdkInput = { command: 'touch /tmp/allowed', nested: { path: '/tmp/allowed' } }
+    const wrapped = adapter.wrapCanUseTool(async (_toolName, input) => {
+      input['command'] = 'touch /tmp/blocked'
+      ;(input['nested'] as Record<string, unknown>)['path'] = '/tmp/blocked'
+      return { behavior: 'allow' }
+    })
+
+    const result = await wrapped('Bash', sdkInput, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      blockedPath: undefined,
+      decisionReason: undefined,
+      toolUseID: 'call-1',
+      agentID: undefined,
+    })
+
+    expect(result).toEqual({ behavior: 'allow' })
+    expect(sdkInput).toEqual({
+      command: 'touch /tmp/allowed',
+      nested: { path: '/tmp/allowed' },
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -572,6 +572,62 @@ describe('toSdkHooks', () => {
     expect(options.hooks.PostToolUseFailure[0]).toEqual({ hooks: [expect.any(Function)] })
   })
 
+  it('rejects permission callbacks that replace governed input', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const callback = adapter.wrapCanUseTool(async () => ({
+      behavior: 'allow',
+      updatedInput: { command: 'touch /tmp/rewritten' },
+    }))
+
+    await expect(
+      callback(
+        'Bash',
+        { command: 'echo safe' },
+        {
+          signal: hookContext.signal,
+          toolUseID: 'call-1',
+          requestId: 'request-1',
+        },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        behavior: 'deny',
+        message: expect.stringContaining('updatedInput is not supported'),
+      }),
+    )
+  })
+
+  it('fails closed on thrown and malformed permission results', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const args = [
+      'Bash',
+      { command: 'echo safe' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    ] as const
+    const thrown = adapter.wrapCanUseTool(async () => {
+      throw new Error('permission backend failed')
+    })
+    const malformed = adapter.wrapCanUseTool(async () => 'allow' as never)
+
+    await expect(thrown(...args)).resolves.toMatchObject({ behavior: 'deny' })
+    await expect(malformed(...args)).resolves.toMatchObject({ behavior: 'deny' })
+  })
+
+  it('preserves normal permission results and documented null responses', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const args = [
+      'Bash',
+      { command: 'echo safe' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    ] as const
+    const allow = { behavior: 'allow' as const }
+    const deny = { behavior: 'deny' as const, message: 'operator denied' }
+
+    await expect(adapter.wrapCanUseTool(async () => allow)(...args)).resolves.toBe(allow)
+    await expect(adapter.wrapCanUseTool(async () => deny)(...args)).resolves.toBe(deny)
+    await expect(adapter.wrapCanUseTool(async () => null)(...args)).resolves.toBeNull()
+  })
+
   it('PreToolUse hook returns no permission decision for passing rules', async () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)
@@ -811,6 +867,30 @@ describe('toSdkHooks', () => {
     expect(sink.filter(AuditAction.CALL_FAILED)).toHaveLength(1)
     expect(sink.filter(AuditAction.CALL_EXECUTED)).toHaveLength(0)
     expect(onPostconditionWarn).toHaveBeenCalledOnce()
+  })
+
+  it('PostToolUse is a no-op after PostToolUseFailure finalized the call', async () => {
+    const sink = makeSink()
+    const adapter = new ClaudeAgentSDKAdapter(
+      makeGuard({ auditSink: sink, tools: { Bash: { side_effect: 'execute' } } }),
+    )
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+
+    await sdkCallback(options, 'PreToolUse')(preInput('Bash', {}), 'call-1', hookContext)
+    await sdkCallback(options, 'PostToolUseFailure')(
+      failureInput('Bash', 'command exited unsuccessfully'),
+      'call-1',
+      hookContext,
+    )
+    const duplicate = await sdkCallback(options, 'PostToolUse')(
+      postInput('Bash', 'ignored'),
+      'call-1',
+      hookContext,
+    )
+
+    expect(duplicate).toEqual({})
+    expect(sink.filter(AuditAction.CALL_FAILED)).toHaveLength(1)
+    expect(sink.filter(AuditAction.CALL_EXECUTED)).toHaveLength(0)
   })
 })
 

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -593,10 +593,26 @@ describe('toSdkHooks', () => {
     await expect(ownReplacement(...args)).resolves.toEqual(
       expect.objectContaining({
         behavior: 'deny',
-        message: expect.stringContaining('updatedInput is not supported'),
+        message: expect.stringContaining('mutations are not supported'),
       }),
     )
     await expect(inheritedReplacement(...args)).resolves.toMatchObject({ behavior: 'deny' })
+
+    const proxyReplacement = new Proxy(
+      { behavior: 'allow' as const },
+      {
+        has: (target, property) =>
+          property === 'updatedInput' ? false : Reflect.has(target, property),
+        get: (target, property, receiver) =>
+          property === 'updatedInput'
+            ? { command: 'touch /tmp/proxy' }
+            : Reflect.get(target, property, receiver),
+      },
+    )
+    const normalized = await adapter.wrapCanUseTool(async () => proxyReplacement)(...args)
+    expect(normalized).toEqual({ behavior: 'allow' })
+    expect(normalized).not.toBe(proxyReplacement)
+    expect('updatedInput' in (normalized as object)).toBe(false)
   })
 
   it('fails closed on thrown and malformed permission results', async () => {
@@ -625,8 +641,8 @@ describe('toSdkHooks', () => {
     const allow = { behavior: 'allow' as const }
     const deny = { behavior: 'deny' as const, message: 'operator denied' }
 
-    await expect(adapter.wrapCanUseTool(async () => allow)(...args)).resolves.toBe(allow)
-    await expect(adapter.wrapCanUseTool(async () => deny)(...args)).resolves.toBe(deny)
+    await expect(adapter.wrapCanUseTool(async () => allow)(...args)).resolves.toEqual(allow)
+    await expect(adapter.wrapCanUseTool(async () => deny)(...args)).resolves.toEqual(deny)
     await expect(adapter.wrapCanUseTool(async () => null)(...args)).resolves.toBeNull()
   })
 

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -669,6 +669,94 @@ describe('toSdkHooks', () => {
     await expect(adapter.wrapCanUseTool(async () => null)(...args)).resolves.toBeNull()
   })
 
+  it('blocks wrapCanUseTool when input differs from pending governed args', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    await adapter._pre('Bash', { command: 'echo safe' }, 'call-1')
+    const wrapped = adapter.wrapCanUseTool(async () => ({ behavior: 'allow' }))
+    const args = [
+      'Bash',
+      { command: 'touch /tmp/rewritten' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    ] as const
+
+    await expect(wrapped(...args)).resolves.toEqual(
+      expect.objectContaining({
+        behavior: 'deny',
+        message: expect.stringContaining('BLOCKED'),
+      }),
+    )
+  })
+
+  it('preserves wrapCanUseTool allow and deny when input matches pending governed args', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    await adapter._pre('Bash', { command: 'echo safe', nested: { n: 1 } }, 'call-1')
+    const args = [
+      'Bash',
+      { nested: { n: 1 }, command: 'echo safe' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    ] as const
+
+    await expect(
+      adapter.wrapCanUseTool(async () => ({ behavior: 'allow' }))(...args),
+    ).resolves.toEqual({ behavior: 'allow' })
+    await expect(
+      adapter.wrapCanUseTool(async () => ({ behavior: 'deny', message: 'operator blocked' }))(
+        ...args,
+      ),
+    ).resolves.toEqual({ behavior: 'deny', message: 'operator blocked' })
+  })
+
+  it('blocks neighbor-hook updatedInput when the SDK hands rewritten args to wrapCanUseTool', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+
+    // A later neighbor PreToolUse hook can return hookSpecificOutput.updatedInput.
+    // The SDK applies that rewrite and then calls canUseTool with the replacement.
+    // There is no second Edictum PreToolUse for that neighbor output, so
+    // wrapCanUseTool is the execution-time gate.
+    const preResult = await sdkCallback(options, 'PreToolUse')(
+      preInput('Bash', { command: 'echo safe' }),
+      'call-1',
+      hookContext,
+    )
+    expect(preResult).toEqual({})
+
+    const result = await adapter.wrapCanUseTool(async () => ({ behavior: 'allow' }))(
+      'Bash',
+      { command: 'touch /tmp/neighbor-rewrite' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        behavior: 'deny',
+        message: expect.stringContaining('BLOCKED'),
+      }),
+    )
+  })
+
+  it('blocks PreToolUse when tool_input is a replacement for a pending call', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+
+    await expect(
+      sdkCallback(options, 'PreToolUse')(
+        preInput('Bash', { command: 'echo safe' }),
+        'call-1',
+        hookContext,
+      ),
+    ).resolves.toEqual({})
+
+    const result = (await sdkCallback(options, 'PreToolUse')(
+      preInput('Bash', { command: 'touch /tmp/replaced' }),
+      'call-1',
+      hookContext,
+    )) as PreToolUseHookOutput
+
+    expect(result.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(result.hookSpecificOutput.permissionDecisionReason).toContain('BLOCKED')
+  })
+
   it('PreToolUse hook returns no permission decision for passing rules', async () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -25,7 +25,7 @@ import {
   type ToolCall,
 } from '@edictum/core'
 
-import { ClaudeAgentSDKAdapter } from '../src/index.js'
+import { ClaudeAgentSDKAdapter, type PreToolUseHookOutput } from '../src/index.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -572,7 +572,7 @@ describe('toSdkHooks', () => {
     expect(options.hooks.PostToolUseFailure[0]).toEqual({ hooks: [expect.any(Function)] })
   })
 
-  it('PreToolUse hook returns allow for passing rules', async () => {
+  it('PreToolUse hook returns no permission decision for passing rules', async () => {
     const guard = makeGuard()
     const adapter = new ClaudeAgentSDKAdapter(guard)
     const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
@@ -583,13 +583,26 @@ describe('toSdkHooks', () => {
       hookContext,
     )
 
-    expect(result).toEqual({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'allow',
-      },
-    })
+    expect(result).toEqual({})
   })
+
+  it.each([null, [], 'string', 42])(
+    'denies PreToolUse when tool_input is malformed: %j',
+    async (toolInput) => {
+      const guard = makeGuard()
+      const adapter = new ClaudeAgentSDKAdapter(guard)
+      const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
+      const input = { ...preInput('Bash', {}), tool_input: toolInput } as PreToolUseHookInput
+
+      const result = (await sdkCallback(options, 'PreToolUse')(
+        input,
+        'call-malformed',
+        hookContext,
+      )) as PreToolUseHookOutput
+
+      expect(result.hookSpecificOutput.permissionDecision).toBe('deny')
+    },
+  )
 
   it('PreToolUse hook returns deny for failing rules', async () => {
     const alwaysDeny: Precondition = {

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -615,6 +615,29 @@ describe('toSdkHooks', () => {
     expect('updatedInput' in (normalized as object)).toBe(false)
   })
 
+  it('rejects permission mutations and contradictory allow classifications', async () => {
+    const adapter = new ClaudeAgentSDKAdapter(makeGuard())
+    const args = [
+      'Bash',
+      { command: 'echo safe' },
+      { signal: hookContext.signal, toolUseID: 'call-1', requestId: 'request-1' },
+    ] as const
+    const withPermissions = adapter.wrapCanUseTool(
+      async () =>
+        ({
+          behavior: 'allow',
+          updatedPermissions: [],
+        }) as never,
+    )
+    const contradictory = adapter.wrapCanUseTool(async () => ({
+      behavior: 'allow',
+      decisionClassification: 'user_reject',
+    }))
+
+    await expect(withPermissions(...args)).resolves.toMatchObject({ behavior: 'deny' })
+    await expect(contradictory(...args)).resolves.toMatchObject({ behavior: 'deny' })
+  })
+
   it('fails closed on thrown and malformed permission results', async () => {
     const adapter = new ClaudeAgentSDKAdapter(makeGuard())
     const args = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   fast-xml-parser: ^5.5.6
   flatted: ^3.4.2
   protobufjs: 7.5.5
+  vitest: 3.2.6
 
 importers:
 
@@ -57,8 +58,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -88,8 +89,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/langchain:
     dependencies:
@@ -116,8 +117,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/openai-agents:
     dependencies:
@@ -144,8 +145,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/otel:
     devDependencies:
@@ -192,8 +193,8 @@ importers:
         specifier: ^8.0.0
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/server:
     devDependencies:
@@ -216,8 +217,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/vercel-ai:
     dependencies:
@@ -244,8 +245,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
 packages:
 
@@ -1040,11 +1041,11 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -1054,20 +1055,23 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2217,16 +2221,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3007,10 +3011,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/type-utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -3135,45 +3139,49 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@3.2.6':
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.6(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@3.2.6':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/pretty-format@3.2.7':
     dependencies:
-      '@vitest/utils': 3.2.4
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
+  '@vitest/spy@3.2.6':
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.6
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -4291,7 +4299,7 @@ snapshots:
 
   typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -4357,16 +4365,16 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.2
 
-  vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
+  vitest@3.2.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,14 +28,19 @@ importers:
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
 
   packages/claude-sdk:
-    dependencies:
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: '>=0.1.0'
-        version: 0.2.76(zod@4.3.6)
     devDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.3.221
+        version: 0.3.221(@anthropic-ai/sdk@0.115.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: 0.115.0
+        version: 0.115.0(zod@4.3.6)
       '@edictum/core':
         specifier: workspace:*
         version: link:../core
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -260,11 +265,66 @@ packages:
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.76':
-    resolution: {integrity: sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.221':
+    resolution: {integrity: sha512-/J4MnpoOqJqrIjH6c6GQAB6Tlcp+kvTEWSM9+5yCkGF2cUmXgaQk7eJlu05ldp+GuSS5AVKq5goIjhYFgY3+Sg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.221':
+    resolution: {integrity: sha512-je33rwPBGEHDoW/kMzoMw/Pg4mcRfvzirkhEx/rykAK4/w0t3Czwt5DeF0HXVQzW+M8bXPN1486wMxONNFLQMw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.221':
+    resolution: {integrity: sha512-Gi84q2ULzWhduMoP69NGwMpo9AibXcO+PtbF0eHCUJAQ/qUu0PxcrTg6S73WotQ2qAP8LhtN6a8x+8EszU64MA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.221':
+    resolution: {integrity: sha512-6HhD/5poDNEpITda9NyTmqwrxaFi4dn5nROLCVC1BG4IhEHfeBIVocr1TAgTy7RjoScr3RHl9SA9OFpUMzuifQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.221':
+    resolution: {integrity: sha512-/tm6HdYV1EnnZJpN9l1yxZGRaE5K+zj0OLycBBHc0CBXtAQ1we/7aMpqX39iJ01c7J5TG9coEJOI/G9K2FhQoQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.221':
+    resolution: {integrity: sha512-pPrpl84Pe563tLci6ndBuBK6IY85RKhcAAJMU73/VPB240yiSnnPaxqKTEgXnw7qbAFYTQ1TOasum/awUs4BdQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.221':
+    resolution: {integrity: sha512-IK2aOH58U7iMM4nAc45B8pcHZhFCUAPml6N8WFBHNr41+hRelI++xEVJpQQk55SyrRQ8HVeCoMeTlp858i9KgQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.221':
+    resolution: {integrity: sha512-vqa6DOMfqSr+JoXqc7p6mjqwuTOYQLdXVBVCOwg7HEc/O0JgrFLeC4lCQs8hIkLrO0r/pBwv8KbfmYz1DwIeew==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.221':
+    resolution: {integrity: sha512-qOXebuNlK5hKkYmXSdSNJHDw4ulAJYQ7hdGuOmv5pXtaRCvfkIRlNGKoiFjGDq55n8aneAp3/BIzAVcxSQln+g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.115.0':
+    resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -517,95 +577,6 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -668,6 +639,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -956,6 +937,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1445,6 +1429,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -1620,6 +1607,10 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2019,6 +2010,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -2086,6 +2080,9 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2160,6 +2157,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -2329,19 +2327,53 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@anthropic-ai/claude-agent-sdk@0.2.76(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.221':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.221(@anthropic-ai/sdk@0.115.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(zod@4.3.6)':
     dependencies:
+      '@anthropic-ai/sdk': 0.115.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.221
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.221
+
+  '@anthropic-ai/sdk@0.115.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@babel/runtime@7.29.7': {}
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -2520,7 +2552,6 @@ snapshots:
   '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
       hono: 4.12.7
-    optional: true
 
   '@humanfs/core@0.19.1': {}
 
@@ -2532,68 +2563,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2686,6 +2655,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.7)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.7
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@openai/agents-core@0.7.1(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
@@ -2963,6 +2956,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
@@ -3012,10 +3007,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/type-utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -3186,7 +3181,6 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
-    optional: true
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -3205,7 +3199,6 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
-    optional: true
 
   ajv@6.14.0:
     dependencies:
@@ -3220,7 +3213,6 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    optional: true
 
   ansi-regex@5.0.1: {}
 
@@ -3255,7 +3247,6 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   brace-expansion@1.1.12:
     dependencies:
@@ -3271,8 +3262,7 @@ snapshots:
       esbuild: 0.27.4
       load-tsconfig: 0.2.5
 
-  bytes@3.1.2:
-    optional: true
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -3280,13 +3270,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    optional: true
 
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    optional: true
 
   callsites@3.1.0: {}
 
@@ -3337,23 +3325,18 @@ snapshots:
     dependencies:
       simple-wcswidth: 1.1.2
 
-  content-disposition@1.0.1:
-    optional: true
+  content-disposition@1.0.1: {}
 
-  content-type@1.0.5:
-    optional: true
+  content-type@1.0.5: {}
 
-  cookie-signature@1.2.2:
-    optional: true
+  cookie-signature@1.2.2: {}
 
-  cookie@0.7.2:
-    optional: true
+  cookie@0.7.2: {}
 
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3371,38 +3354,31 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  depd@2.0.0:
-    optional: true
+  depd@2.0.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
-  ee-first@1.1.1:
-    optional: true
+  ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
 
-  encodeurl@2.0.0:
-    optional: true
+  encodeurl@2.0.0: {}
 
   entities@4.5.0: {}
 
-  es-define-property@1.0.1:
-    optional: true
+  es-define-property@1.0.1: {}
 
-  es-errors@1.3.0:
-    optional: true
+  es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-    optional: true
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -3435,8 +3411,7 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-html@1.0.3:
-    optional: true
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3564,8 +3539,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1:
-    optional: true
+  etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
 
@@ -3576,7 +3550,6 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
-    optional: true
 
   expect-type@1.3.0: {}
 
@@ -3584,7 +3557,6 @@ snapshots:
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
-    optional: true
 
   express@5.2.1:
     dependencies:
@@ -3618,7 +3590,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   fast-deep-equal@3.1.3: {}
 
@@ -3626,8 +3597,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0:
-    optional: true
+  fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3647,7 +3619,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   find-up@5.0.0:
     dependencies:
@@ -3667,17 +3638,14 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  forwarded@0.2.0:
-    optional: true
+  forwarded@0.2.0: {}
 
-  fresh@2.0.0:
-    optional: true
+  fresh@2.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2:
-    optional: true
+  function-bind@1.1.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -3693,13 +3661,11 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    optional: true
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -3707,21 +3673,17 @@ snapshots:
 
   globals@14.0.0: {}
 
-  gopd@1.2.0:
-    optional: true
+  gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
 
-  has-symbols@1.1.0:
-    optional: true
+  has-symbols@1.1.0: {}
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
-  hono@4.12.7:
-    optional: true
+  hono@4.12.7: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -3730,14 +3692,12 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-    optional: true
 
   husky@9.1.7: {}
 
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
-    optional: true
 
   ignore@5.3.2: {}
 
@@ -3750,14 +3710,11 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
-  ip-address@10.1.0:
-    optional: true
+  ip-address@10.1.0: {}
 
-  ipaddr.js@1.9.1:
-    optional: true
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -3769,16 +3726,14 @@ snapshots:
 
   is-network-error@1.3.1: {}
 
-  is-promise@4.0.0:
-    optional: true
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
   jiti@2.6.1:
     optional: true
 
-  jose@6.2.1:
-    optional: true
+  jose@6.2.1: {}
 
   joycon@3.1.1: {}
 
@@ -3794,13 +3749,16 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0:
-    optional: true
+  json-schema-traverse@1.0.0: {}
 
-  json-schema-typed@8.0.2:
-    optional: true
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -3887,24 +3845,19 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  math-intrinsics@1.1.0:
-    optional: true
+  math-intrinsics@1.1.0: {}
 
   mdurl@2.0.0: {}
 
-  media-typer@1.1.0:
-    optional: true
+  media-typer@1.1.0: {}
 
-  merge-descriptors@2.0.0:
-    optional: true
+  merge-descriptors@2.0.0: {}
 
-  mime-db@1.54.0:
-    optional: true
+  mime-db@1.54.0: {}
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
-    optional: true
 
   minimatch@10.2.4:
     dependencies:
@@ -3935,23 +3888,19 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@1.0.0:
-    optional: true
+  negotiator@1.0.0: {}
 
   object-assign@4.1.1: {}
 
-  object-inspect@1.13.4:
-    optional: true
+  object-inspect@1.13.4: {}
 
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
-    optional: true
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   openai@6.29.0(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
@@ -4001,15 +3950,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parseurl@1.3.3:
-    optional: true
+  parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
-  path-to-regexp@8.3.0:
-    optional: true
+  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -4021,8 +3968,7 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  pkce-challenge@5.0.1:
-    optional: true
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -4067,7 +4013,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -4076,10 +4021,8 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
-    optional: true
 
-  range-parser@1.2.1:
-    optional: true
+  range-parser@1.2.1: {}
 
   raw-body@3.0.2:
     dependencies:
@@ -4087,14 +4030,12 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-    optional: true
 
   readdirp@4.1.2: {}
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -4140,10 +4081,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  safer-buffer@2.1.2:
-    optional: true
+  safer-buffer@2.1.2: {}
 
   semver@7.7.4: {}
 
@@ -4162,7 +4101,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   serve-static@2.2.1:
     dependencies:
@@ -4172,10 +4110,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  setprototypeof@1.2.0:
-    optional: true
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4187,7 +4123,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-map@1.0.1:
     dependencies:
@@ -4195,7 +4130,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-weakmap@1.0.2:
     dependencies:
@@ -4204,7 +4138,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    optional: true
 
   side-channel@1.1.0:
     dependencies:
@@ -4213,7 +4146,6 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    optional: true
 
   siginfo@2.0.0: {}
 
@@ -4225,8 +4157,12 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.2:
-    optional: true
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -4283,10 +4219,11 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  toidentifier@1.0.1:
-    optional: true
+  toidentifier@1.0.1: {}
 
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4331,7 +4268,6 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
-    optional: true
 
   typedoc@0.28.18(typescript@5.9.3):
     dependencies:
@@ -4355,7 +4291,7 @@ snapshots:
 
   typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -4372,8 +4308,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  unpipe@1.0.0:
-    optional: true
+  unpipe@1.0.0: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -4385,8 +4320,7 @@ snapshots:
 
   uuid@13.0.0: {}
 
-  vary@1.1.2:
-    optional: true
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
@@ -4481,8 +4415,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 
@@ -4507,6 +4440,5 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-    optional: true
 
   zod@4.3.6: {}


### PR DESCRIPTION
## Summary

- make `toSdkHooks()` return Claude Agent SDK matcher objects and native three-argument callbacks
- preserve the SDK permission layer after Edictum passes and reject post-governance input rewrites
- finalize both successful and failed tool exits, with SDK failure events authoritative over custom success checks
- pin and type-check against `@anthropic-ai/claude-agent-sdk@0.3.221`
- make native post hooks explicitly detection/warning-only because generic output cannot preserve per-tool result schemas
- ship the breaking public API correction as `@edictum/claude-sdk` 0.3.0
- pin patched Vitest 3.2.6 after the CI audit found GHSA-5xrq-8626-4rwp

## Breaking change

This fixes the public method in place. Callers that inspected or invoked its former bare callback arrays must update to matcher objects and native callback arguments. The exported hook aliases now resolve to the SDK-native types. Correct SDK wiring is `options: { hooks: adapter.toSdkHooks() }`.

Adoption is currently zero, so retaining a broken compatibility path would create a larger future migration at no present benefit.

## Primary contract

Installed package: `@anthropic-ai/claude-agent-sdk@0.3.221`, published 2026-08-03.

- `Options.hooks`: `Partial<Record<HookEvent, HookCallbackMatcher[]>>`
- matcher: `{ matcher?: string; hooks: HookCallback[]; timeout?: number }`
- callback: `(input, toolUseID, { signal }) => Promise<HookJSONOutput>`
- `PreToolUse.permissionDecision` is optional; Edictum returns no decision on pass so the SDK permission layer remains active
- `canUseTool.updatedInput` executes without another `PreToolUse`; configured callbacks must use the new fail-closed `wrapCanUseTool()` boundary, which normalizes decisions and rejects input or permission mutations

The exact dependency and its required peer dependencies are pinned. The selected versions satisfy the project cooldown.

## Live SDK evidence

```text
CONTROL:    SDK_RESULT=success HOOK_DENIED=NO  SENTINEL=PRESENT
BLOCK:      SDK_RESULT=success HOOK_DENIED=YES SENTINEL=ABSENT
PERMISSION: SDK_RESULT=success PERMISSION_CALLBACK_CALLED=YES PERMISSION_MUTATION_ISOLATED=YES ORIGINAL_INPUT_EXECUTED=YES SENTINEL=ABSENT
FAILURE:    SDK_RESULT=success FAILURE_HOOK_CALLED=YES CALL_FAILED_AUDIT_COUNT=1
```

The control and block runs used the same pre-approved Bash `touch`; the Edictum hook was the sole delta. The permission run removed pre-approval, had `canUseTool` mutate a detached copy of a benign command into the forbidden `touch`, and proved that the SDK-owned original input executed unchanged.

The live Read post-hook probe received the built-in `{file,type}` result, detected the probe, fired the warning callback, returned no `updatedToolOutput`, and the model received the original result. Native post-hooks therefore make no suppression claim for built-in or MCP tools; use preconditions when output must be blocked.

## Verification

- pre-commit gate: build, lint, format, typecheck, all 1,319 tests passed
- Claude adapter tests: 48/48 passed
- real SDK control, block, permission, post, and failure runs passed
- reverted-source check: final regression test failed because `PostToolUseFailure` was absent; the earlier shape-only check also received a bare function instead of `{ hooks: [...] }`
- two independent adversarial reviews completed; actionable findings addressed
- `pnpm audit --audit-level=critical` exits zero after the Vitest patch pin

## Report-only findings

- `@edictum/edictum@0.5.2` source is in the separate `edictum-ai/edictum-openclaw` repository at npm `gitHead` `6255b9e6aa9ed00a2e3fcdcf23a41bd92e8e22c0`. The tarball contains built artifacts, declarations, maps with embedded source content, root plugin files, and the rules contract. npm publishes a SLSA provenance attestation. This monorepo contains no OpenClaw reference. Ownership/location should be made explicit, moved into this monorepo, or the package should be retired; no provenance change is included here.
- Integration-shape sweep: Claude is clean after this change. LangChain 1.2.32, OpenAI Agents 0.7.1, and Vercel AI SDK 6.0.116 each have separate type/semantic integration gaps that need their own scoped fixes. Their `DENIED: ...` strings are caller-side diagnostics, not host wire decisions.
- Post finalization is at-most-once. Postconditions, workflow storage, session storage, and audit sinks have no shared transaction/idempotency contract, so a thrown finalization step is propagated but not retried to avoid duplicating durable state.



