### PR TITLE
fix(test): fail required conformance on empty or invalid fixture sets

### DIFF
--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -34,4 +34,4 @@ jobs:
         pnpm --filter @edictum/core build &&
         EDICTUM_CONFORMANCE_REQUIRED=1
         pnpm --filter @edictum/core test -- tests/yaml-engine/shared-fixtures.test.ts
-      fixture-ref: 59df5f7f029f7ddcde35e35343405a62c7a405ce
+      fixture-ref: c0cfa040c80b7ec22a10a6960108e82196025693

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -18,11 +18,12 @@ concurrency:
 jobs:
   gate:
     # Pin points at the sdk-gate commit that exports absolute
-    # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR.
+    # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR
+    # (edictum-ai/.github#8dcbbf3, landed on main).
     # The inline relative EDICTUM_SCHEMAS_DIR assignment is gone on
     # purpose: it shadowed the workflow's export with a path that only
     # resolved via the runner's nested-checkout fallback.
-    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@d82a6556454dd3707043cc21a728569397693de4
+    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@8dcbbf351385ad493929531f4181aa0616a8dfe6
     with:
       runner: blacksmith-2vcpu-ubuntu-2404-arm
       runtime: node

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -21,7 +21,7 @@ jobs:
     # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR
     # (edictum-ai/.github#8dcbbf3, landed on main).
     # The inline relative EDICTUM_SCHEMAS_DIR assignment is gone on
-    # purpose: it shadowed the workflow's export with a path that only
+    # purpose: it overrode the workflow's export with a path that only
     # resolved via the runner's nested-checkout fallback.
     uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@8dcbbf351385ad493929531f4181aa0616a8dfe6
     with:
@@ -34,4 +34,5 @@ jobs:
         pnpm --filter @edictum/core build &&
         EDICTUM_CONFORMANCE_REQUIRED=1
         pnpm --filter @edictum/core test -- tests/yaml-engine/shared-fixtures.test.ts
+        tests/workflow/workflow-v018-conformance.test.ts
       fixture-ref: c0cfa040c80b7ec22a10a6960108e82196025693

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -17,7 +17,12 @@ concurrency:
 
 jobs:
   gate:
-    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@a8b075f4d60354e79bd26e06353c5367b75296b2
+    # Pin points at the sdk-gate commit that exports absolute
+    # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR.
+    # The inline relative EDICTUM_SCHEMAS_DIR assignment is gone on
+    # purpose: it shadowed the workflow's export with a path that only
+    # resolved via the runner's nested-checkout fallback.
+    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@d82a6556454dd3707043cc21a728569397693de4
     with:
       runner: blacksmith-2vcpu-ubuntu-2404-arm
       runtime: node
@@ -26,7 +31,6 @@ jobs:
       test-command: pnpm -r build && pnpm -r test
       conformance-command: >-
         pnpm --filter @edictum/core build &&
-        EDICTUM_SCHEMAS_DIR=edictum-schemas
         EDICTUM_CONFORMANCE_REQUIRED=1
         pnpm --filter @edictum/core test -- tests/yaml-engine/shared-fixtures.test.ts
-      fixture-ref: bfb633c6019d6b545f5d0e8986c05d9a95087520
+      fixture-ref: 59df5f7f029f7ddcde35e35343405a62c7a405ce

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,11 +226,13 @@ When a change affects shared semantics, YAML validation, fixture behavior, audit
 3. **Ensure all three SDKs pass** — Python (`edictum`), Go (`edictum-go`), and TypeScript (this repo) shared-fixture runners must all pass with `EDICTUM_CONFORMANCE_REQUIRED=1`
 4. **Do not merge** parity-affecting behavior without the Parity Check workflow passing in all affected repos
 
-The conformance runner in this repo lives at `packages/core/tests/yaml-engine/shared-fixtures.test.ts` and is executed in CI by:
+The conformance runner in this repo lives at `packages/core/tests/yaml-engine/shared-fixtures.test.ts` and is executed in CI by the command below.
+
+A relative schemas-dir value is resolved from cwd and from the repo root (so it still works when core tests run with cwd packages/core).
 
 ```bash
 EDICTUM_SCHEMAS_DIR=edictum-schemas EDICTUM_CONFORMANCE_REQUIRED=1 \
-  pnpm --filter @edictum/core test -- --grep "shared rejection fixtures"
+  pnpm --filter @edictum/core test -- tests/yaml-engine/shared-fixtures.test.ts
 ```
 
 The `Parity Check` workflow (`.github/workflows/parity-check.yml`) runs on PRs to main, pushes to main, and weekly. It is intended to be a required status check.

--- a/packages/core/tests/workflow/v018-conformance-gate-helpers.ts
+++ b/packages/core/tests/workflow/v018-conformance-gate-helpers.ts
@@ -6,6 +6,15 @@ const V018 = join('fixtures', 'workflow-v0.18')
 
 const MINIMAL_SUITE = [
   'suite: placeholder',
+  'workflows:',
+  '  unused:',
+  '    apiVersion: edictum/v1',
+  '    kind: Workflow',
+  '    metadata:',
+  '      name: unused',
+  '    stages:',
+  '      - id: unused',
+  '        tools: []',
   'fixtures:',
   '  - id: present',
   '    description: nonempty so this named suite is loaded',

--- a/packages/core/tests/workflow/v018-conformance-gate-helpers.ts
+++ b/packages/core/tests/workflow/v018-conformance-gate-helpers.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const V018 = join('fixtures', 'workflow-v0.18')
+
+const MINIMAL_SUITE = [
+  'suite: placeholder',
+  'fixtures:',
+  '  - id: present',
+  '    description: nonempty so this named suite is loaded',
+  '    workflow: unused',
+  '    contract: unused',
+  '    envelope:',
+  '      tool_name: unused',
+  '    expected:',
+  '      verdict: allowed',
+  '    initial_state: {}',
+  '    steps: []',
+  '',
+].join('\n')
+
+function writeSuite(root: string, filename: string, body: string): void {
+  writeFileSync(join(root, V018, filename), body)
+}
+
+/** Temp schemas root whose workflow-v0.18 directory exists but is empty. */
+export function makeEmptyV018Dir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-v018-empty-'))
+  mkdirSync(join(root, V018), { recursive: true })
+  return root
+}
+
+/** Temp schemas root with no fixtures tree (wrong-ref checkout shape). */
+export function makeWrongRefRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'edictum-v018-wrongref-'))
+}
+
+/** Only one of the four named suite files is present. */
+export function makePartialV018Dir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-v018-partial-'))
+  mkdirSync(join(root, V018), { recursive: true })
+  writeSuite(root, 'wildcard-tools.workflow-v0.18.yaml', MINIMAL_SUITE)
+  return root
+}
+
+/** All four named files present; extends carries an unknown verdict. */
+export function makeUnknownVerdictDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-v018-verdict-'))
+  mkdirSync(join(root, V018), { recursive: true })
+  writeSuite(root, 'wildcard-tools.workflow-v0.18.yaml', MINIMAL_SUITE)
+  writeSuite(root, 'terminal-stage.workflow-v0.18.yaml', MINIMAL_SUITE)
+  writeSuite(root, 'mcp-result-evidence.workflow-v0.18.yaml', MINIMAL_SUITE)
+  writeSuite(
+    root,
+    'extends-inheritance.workflow-v0.18.yaml',
+    [
+      'suite: extends-inheritance',
+      'rulesets: {}',
+      'fixtures:',
+      '  - id: sab-unknown-verdict',
+      '    description: unknown expected.verdict must fail closed',
+      '    contract: unused',
+      '    envelope:',
+      '      tool_name: unused',
+      '    expected:',
+      '      verdict: not-a-real-verdict',
+      '',
+    ].join('\n'),
+  )
+  return root
+}

--- a/packages/core/tests/workflow/v018-conformance-gate.test.ts
+++ b/packages/core/tests/workflow/v018-conformance-gate.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for the fail-closed gate of the v0.18 workflow runner.
+ * The gate fires at module import, so these spawn the real runner.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, rmSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  makeEmptyV018Dir,
+  makePartialV018Dir,
+  makeUnknownVerdictDir,
+  makeWrongRefRoot,
+} from './v018-conformance-gate-helpers.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const CORE_ROOT = resolve(HERE, '..', '..')
+const RUNNER_FILE = 'tests/workflow/workflow-v018-conformance.test.ts'
+const require = createRequire(import.meta.url)
+const VITEST_ENTRY = require.resolve('vitest/vitest.mjs')
+
+function runRunner(env: Record<string, string>): { status: number | null; output: string } {
+  if (!existsSync(VITEST_ENTRY)) {
+    throw new Error(`vitest CLI entry not found at ${VITEST_ENTRY}`)
+  }
+  const childEnv: NodeJS.ProcessEnv = { ...process.env }
+  delete childEnv.EDICTUM_SCHEMAS_DIR
+  delete childEnv.EDICTUM_FIXTURES_DIR
+  delete childEnv.EDICTUM_CONFORMANCE_REQUIRED
+  Object.assign(childEnv, env)
+  const vitestArgs = [VITEST_ENTRY, 'run', '--reporter=verbose', RUNNER_FILE]
+  const result = spawnSync(process.execPath, vitestArgs, {
+    cwd: CORE_ROOT,
+    env: childEnv,
+    encoding: 'utf8',
+    timeout: 150_000,
+  })
+  return { status: result.status, output: `${result.stdout ?? ''}\n${result.stderr ?? ''}` }
+}
+
+describe('workflow-v0.18 runner — fail-closed gates', () => {
+  it('required mode: empty v0.18 directory fails the run', { timeout: 180_000 }, () => {
+    const root = makeEmptyV018Dir()
+    try {
+      const result = runRunner({ EDICTUM_SCHEMAS_DIR: root, EDICTUM_CONFORMANCE_REQUIRED: '1' })
+      expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+      expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+      expect(result.output).toContain('no workflow-v0.18 fixtures were loaded')
+      expect(result.output).toContain('empty suites:')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('workflow-v0.18 runner — per-suite and verdict gates', () => {
+  it(
+    'required mode: one nonempty suite still fails when the other three are empty',
+    { timeout: 180_000 },
+    () => {
+      const root = makePartialV018Dir()
+      try {
+        const result = runRunner({
+          EDICTUM_SCHEMAS_DIR: root,
+          EDICTUM_CONFORMANCE_REQUIRED: '1',
+        })
+        expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+        expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+        expect(result.output).toContain('no workflow-v0.18 fixtures were loaded')
+        expect(result.output).toContain('terminal-stage')
+        expect(result.output).toContain('extends-inheritance')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it('required mode: unknown extends verdict fails the run', { timeout: 180_000 }, () => {
+    const root = makeUnknownVerdictDir()
+    try {
+      const result = runRunner({ EDICTUM_SCHEMAS_DIR: root, EDICTUM_CONFORMANCE_REQUIRED: '1' })
+      expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+      expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+      expect(result.output).toContain('unknown expected verdict')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('required mode: wrong EDICTUM_SCHEMAS_DIR refuses fallthrough', { timeout: 180_000 }, () => {
+    const root = makeWrongRefRoot()
+    try {
+      const result = runRunner({ EDICTUM_SCHEMAS_DIR: root, EDICTUM_CONFORMANCE_REQUIRED: '1' })
+      expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+      expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+      expect(result.output).toContain('refusing to fall through')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('optional mode: empty v0.18 directory stays a named skip', { timeout: 180_000 }, () => {
+    const root = makeEmptyV018Dir()
+    try {
+      const result = runRunner({ EDICTUM_SCHEMAS_DIR: root })
+      expect(result.status, `runner output:\n${result.output}`).toBe(0)
+      expect(result.output).toContain(
+        'workflow-v0.18 conformance — edictum-schemas not found or empty',
+      )
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/core/tests/workflow/workflow-v018-conformance.test.ts
+++ b/packages/core/tests/workflow/workflow-v018-conformance.test.ts
@@ -2,12 +2,21 @@
  * Conformance runner for v0.18 workflow fixtures from edictum-schemas.
  *
  * Fixture discovery (first match wins):
- *   1. EDICTUM_SCHEMAS_DIR env var / fixtures/workflow-v0.18/
+ *   1. EDICTUM_SCHEMAS_DIR env var / fixtures/workflow-v0.18/. A relative
+ *      value is resolved against cwd and then the repo root.
  *   2. <repo-root>/edictum-schemas/fixtures/workflow-v0.18/
  *   3. <repo-root>/../edictum-schemas/fixtures/workflow-v0.18/
  *
- * Missing-fixture behavior:
- *   - Skip the suite cleanly (check out edictum-schemas sibling to run locally)
+ * Missing-fixture behavior — gated on each named suite's loaded fixture
+ * list, not on the directory existing or on the union of the four lists
+ * (matches edictum#242):
+ *   - EDICTUM_CONFORMANCE_REQUIRED=1 with any of the four named suites
+ *     empty (missing directory, empty directory, or a missing/empty
+ *     suite file) → fail the test run
+ *   - Otherwise → skip the empty suite cleanly (a named skip, never a pass)
+ *
+ * An explicitly-set EDICTUM_SCHEMAS_DIR whose workflow-v0.18 subdirectory
+ * does not exist refuses fallthrough in required mode.
  */
 
 import { existsSync, readFileSync } from 'node:fs'
@@ -33,20 +42,54 @@ import type { MutableWorkflowState, MutableWorkflowEvidence } from '../../src/wo
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(HERE, '..', '..', '..', '..')
 
-function findV018Dir(): string | null {
-  const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
-  if (schemasEnv) {
-    const candidate = join(schemasEnv, 'fixtures', 'workflow-v0.18')
+const V018_SUBPATH = join('fixtures', 'workflow-v0.18')
+const V018_SUITE_FILES = [
+  ['wildcard-tools', 'wildcard-tools.workflow-v0.18.yaml'],
+  ['terminal-stage', 'terminal-stage.workflow-v0.18.yaml'],
+  ['mcp-result-evidence', 'mcp-result-evidence.workflow-v0.18.yaml'],
+  ['extends-inheritance', 'extends-inheritance.workflow-v0.18.yaml'],
+] as const
+
+const FALLBACK_V018_DIRS = [
+  join(REPO_ROOT, 'edictum-schemas', V018_SUBPATH),
+  resolve(REPO_ROOT, '..', 'edictum-schemas', V018_SUBPATH),
+]
+
+function firstExisting(paths: readonly string[]): string | null {
+  for (const candidate of paths) {
     if (existsSync(candidate)) return candidate
   }
-  const nested = join(REPO_ROOT, 'edictum-schemas', 'fixtures', 'workflow-v0.18')
-  if (existsSync(nested)) return nested
-  const sibling = resolve(REPO_ROOT, '..', 'edictum-schemas', 'fixtures', 'workflow-v0.18')
-  if (existsSync(sibling)) return sibling
   return null
 }
 
-const v018Dir = findV018Dir()
+function envV018Candidates(schemasEnv: string): string[] {
+  const fromCwd = resolve(process.cwd(), schemasEnv, V018_SUBPATH)
+  const fromRoot = resolve(REPO_ROOT, schemasEnv, V018_SUBPATH)
+  return fromCwd === fromRoot ? [fromCwd] : [fromCwd, fromRoot]
+}
+
+const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
+const conformanceRequired = process.env.EDICTUM_CONFORMANCE_REQUIRED === '1'
+const envCandidates = schemasEnv ? envV018Candidates(schemasEnv) : []
+const envHit = firstExisting(envCandidates)
+const fallbackHit = firstExisting(FALLBACK_V018_DIRS)
+
+if (schemasEnv && !envHit) {
+  if (conformanceRequired) {
+    throw new Error(
+      `EDICTUM_SCHEMAS_DIR is set to "${schemasEnv}" but none of the resolved ` +
+        `${V018_SUBPATH} directories exist — refusing to fall through to ` +
+        `repo-relative discovery. Tried: ${envCandidates.join(', ')}. ` +
+        'Fix the schemas checkout or unset the variable.',
+    )
+  }
+  console.warn(
+    `[edictum] EDICTUM_SCHEMAS_DIR="${schemasEnv}" has no ${V018_SUBPATH} ` +
+      `at tried paths [${envCandidates.join(', ')}]; falling back to repo-relative discovery.`,
+  )
+}
+
+const v018Dir = envHit ?? fallbackHit
 
 function loadSuite(filename: string): Record<string, unknown> | null {
   if (!v018Dir) return null
@@ -56,6 +99,32 @@ function loadSuite(filename: string): Record<string, unknown> | null {
     string,
     unknown
   >
+}
+
+function suiteFixtures(suite: Record<string, unknown> | null): Record<string, unknown>[] {
+  if (suite == null || !Array.isArray(suite.fixtures)) return []
+  return suite.fixtures as Record<string, unknown>[]
+}
+
+const loadedSuites = V018_SUITE_FILES.map(([name, file]) => {
+  const suite = loadSuite(file)
+  return { name, file, suite, fixtures: suiteFixtures(suite) }
+})
+const emptySuites = loadedSuites
+  .filter((entry) => entry.fixtures.length === 0)
+  .map((entry) => entry.name)
+
+if (conformanceRequired && emptySuites.length > 0) {
+  const location = v018Dir ? ` from ${v018Dir}` : ' — the fixtures directory was not found'
+  const alreadySet = schemasEnv
+    ? `EDICTUM_SCHEMAS_DIR is already set to "${schemasEnv}"`
+    : 'Set EDICTUM_SCHEMAS_DIR or check out edictum-schemas as a sibling'
+  throw new Error(
+    'EDICTUM_CONFORMANCE_REQUIRED=1 but no workflow-v0.18 fixtures were loaded' +
+      ` (empty suites: ${emptySuites.join(', ')})` +
+      location +
+      `. ${alreadySet}.`,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +297,17 @@ async function runExtendsFixture(
   const rulesetRef = String(fixture.contract)
   const envelopeData = fixture.envelope as Record<string, unknown>
   const expected = fixture.expected as Record<string, unknown>
+  const verdict = expected.verdict
+  if (
+    verdict !== 'denied' &&
+    verdict !== 'block' &&
+    verdict !== 'blocked' &&
+    verdict !== 'allowed'
+  ) {
+    throw new Error(
+      `fixture ${String(fixture.id)}: unknown expected verdict ${JSON.stringify(verdict)}`,
+    )
+  }
 
   const merged = resolveRulesetExtends(rulesets, rulesetRef)
   const mergedYaml = yaml.dump(merged)
@@ -237,10 +317,10 @@ async function runExtendsFixture(
   const args = (envelopeData.arguments ?? {}) as Record<string, unknown>
   const result = await guard.evaluate(toolName, args)
 
-  // Fixture format uses 'denied' as the blocked-verdict string (cross-SDK convention from
-  // edictum-schemas). EvaluationResult.decision uses 'deny' internally. Assert on the raw
-  // decision value to prevent terminology regressions.
-  if (expected.verdict === 'denied') {
+  // Known verdicts match edictum#242: allowed / block|blocked|denied.
+  // Anything else is a hard failure — an unknown verdict must not pass as
+  // "not deny".
+  if (verdict === 'denied' || verdict === 'block' || verdict === 'blocked') {
     expect(result.decision, `fixture ${String(fixture.id)}: verdict`).toBe('deny')
     if (typeof expected.message_contains === 'string') {
       const allReasons = result.denyReasons.join(' ').toLowerCase()
@@ -248,8 +328,12 @@ async function runExtendsFixture(
         expected.message_contains.toLowerCase(),
       )
     }
-  } else {
+  } else if (verdict === 'allowed') {
     expect(result.decision, `fixture ${String(fixture.id)}: verdict`).not.toBe('deny')
+  } else {
+    throw new Error(
+      `fixture ${String(fixture.id)}: unknown expected verdict ${JSON.stringify(verdict)}`,
+    )
   }
 }
 
@@ -257,76 +341,25 @@ async function runExtendsFixture(
 // Test suites
 // ---------------------------------------------------------------------------
 
-if (v018Dir) {
-  describe('workflow-v0.18 conformance', () => {
-    // --- wildcard tools ---
-    describe('wildcard-tools', () => {
-      const suite = loadSuite('wildcard-tools.workflow-v0.18.yaml')
-      if (suite == null) {
-        it.skip('fixture file not found', () => {})
-      } else {
-        const fixtures = Array.isArray(suite.fixtures)
-          ? (suite.fixtures as Record<string, unknown>[])
-          : []
-        for (const fixture of fixtures) {
-          it(`${String(suite.suite ?? 'wildcard-tools')}/${String(fixture.id)}: ${String(fixture.description ?? '')}`, async () => {
-            await runWorkflowFixture(suite, fixture)
-          })
-        }
-      }
-    })
-
-    // --- terminal stage ---
-    describe('terminal-stage', () => {
-      const suite = loadSuite('terminal-stage.workflow-v0.18.yaml')
-      if (suite == null) {
-        it.skip('fixture file not found', () => {})
-      } else {
-        const fixtures = Array.isArray(suite.fixtures)
-          ? (suite.fixtures as Record<string, unknown>[])
-          : []
-        for (const fixture of fixtures) {
-          it(`${String(suite.suite ?? 'terminal-stage')}/${String(fixture.id)}: ${String(fixture.description ?? '')}`, async () => {
-            await runWorkflowFixture(suite, fixture)
-          })
-        }
-      }
-    })
-
-    // --- MCP result evidence ---
-    describe('mcp-result-evidence', () => {
-      const suite = loadSuite('mcp-result-evidence.workflow-v0.18.yaml')
-      if (suite == null) {
-        it.skip('fixture file not found', () => {})
-      } else {
-        const fixtures = Array.isArray(suite.fixtures)
-          ? (suite.fixtures as Record<string, unknown>[])
-          : []
-        for (const fixture of fixtures) {
-          it(`${String(suite.suite ?? 'mcp-result-evidence')}/${String(fixture.id)}: ${String(fixture.description ?? '')}`, async () => {
-            await runWorkflowFixture(suite, fixture)
-          })
-        }
-      }
-    })
-
-    // --- extends inheritance ---
-    describe('extends-inheritance', () => {
-      const suite = loadSuite('extends-inheritance.workflow-v0.18.yaml')
-      if (suite == null) {
-        it.skip('fixture file not found', () => {})
-      } else {
-        const fixtures = Array.isArray(suite.fixtures)
-          ? (suite.fixtures as Record<string, unknown>[])
-          : []
-        for (const fixture of fixtures) {
-          it(`${String(suite.suite ?? 'extends-inheritance')}/${String(fixture.id)}: ${String(fixture.description ?? '')}`, async () => {
-            await runExtendsFixture(suite, fixture)
-          })
-        }
-      }
-    })
-  })
+if (emptySuites.length === 4) {
+  it.skip('workflow-v0.18 conformance — edictum-schemas not found or empty', () => {})
 } else {
-  it.skip('workflow-v0.18 conformance — edictum-schemas not found', () => {})
+  describe('workflow-v0.18 conformance', () => {
+    for (const entry of loadedSuites) {
+      describe(entry.name, () => {
+        if (entry.suite == null || entry.fixtures.length === 0) {
+          it.skip('fixture file not found or empty', () => {})
+          return
+        }
+        const run = entry.name === 'extends-inheritance' ? runExtendsFixture : runWorkflowFixture
+        for (const fixture of entry.fixtures) {
+          it(`${String(entry.suite.suite ?? entry.name)}/${String(fixture.id)}: ${String(
+            fixture.description ?? '',
+          )}`, async () => {
+            await run(entry.suite as Record<string, unknown>, fixture)
+          })
+        }
+      })
+    }
+  })
 }

--- a/packages/core/tests/yaml-engine/conformance-gate-helpers.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate-helpers.ts
@@ -1,0 +1,37 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/** Temp schemas root whose rejection directory exists but is empty. */
+export function makeEmptyRejectionDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-gate-empty-'))
+  mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
+  return root
+}
+
+/** Temp schemas root with no fixtures tree (wrong-ref checkout shape). */
+export function makeWrongRefRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'edictum-gate-wrongref-'))
+}
+
+/** Create a temp schemas root with one suite file whose fixtures lack expected.rejected. */
+export function makeMissingExpectationDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-gate-expect-'))
+  mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
+  writeFileSync(
+    join(root, 'fixtures', 'rejection', 'sabotage.rejection.yaml'),
+    [
+      'suite: sabotage',
+      'description: fixture entry with a misspelled expectation key',
+      'fixtures:',
+      '  - id: sab-001',
+      '    description: expectation key misspelled as rejectd',
+      '    bundle: {}',
+      '    expected:',
+      '      rejectd: true',
+      '      error_contains: whatever',
+      '',
+    ].join('\n'),
+  )
+  return root
+}

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -17,7 +17,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
@@ -25,7 +25,8 @@ import { describe, expect, it } from 'vitest'
 const HERE = dirname(fileURLToPath(import.meta.url))
 const CORE_ROOT = resolve(HERE, '..', '..')
 const RUNNER_FILE = 'tests/yaml-engine/shared-fixtures.test.ts'
-const VITEST_BIN = join(CORE_ROOT, 'node_modules', '.bin', 'vitest')
+const REPO_ROOT = resolve(CORE_ROOT, '..', '..')
+const VITEST_ENTRY = fileURLToPath(import.meta.resolve('vitest/vitest.mjs'))
 
 interface RunnerResult {
   status: number | null
@@ -38,8 +39,8 @@ interface RunnerResult {
  * stripped so a parent conformance run cannot leak into the child.
  */
 function runRunner(env: Record<string, string>): RunnerResult {
-  if (!existsSync(VITEST_BIN)) {
-    throw new Error(`vitest binary not found at ${VITEST_BIN} — run pnpm install first`)
+  if (!existsSync(VITEST_ENTRY)) {
+    throw new Error(`vitest CLI entry not found at ${VITEST_ENTRY} — run pnpm install first`)
   }
 
   const childEnv: NodeJS.ProcessEnv = { ...process.env }
@@ -48,7 +49,7 @@ function runRunner(env: Record<string, string>): RunnerResult {
   delete childEnv.EDICTUM_CONFORMANCE_REQUIRED
   Object.assign(childEnv, env)
 
-  const result = spawnSync(VITEST_BIN, ['run', RUNNER_FILE], {
+  const result = spawnSync(process.execPath, [VITEST_ENTRY, 'run', RUNNER_FILE], {
     cwd: CORE_ROOT,
     env: childEnv,
     encoding: 'utf8',
@@ -164,10 +165,45 @@ describe('shared rejection runner — fail-closed gates', () => {
       try {
         const result = runRunner({ EDICTUM_SCHEMAS_DIR: root })
         expect(result.status, `runner output:\n${result.output}`).toBe(0)
-        expect(result.output).toContain('skipped')
+        expect(result.output).toContain('edictum-schemas not found or empty (optional mode)')
       } finally {
         rmSync(root, { recursive: true, force: true })
       }
+    },
+  )
+
+  it(
+    'required mode: relative EDICTUM_SCHEMAS_DIR resolves from repo root, not only cwd',
+    { timeout: 180_000 },
+    () => {
+      const root = makeEmptyRejectionDir()
+      try {
+        const rel = relative(REPO_ROOT, root)
+        const result = runRunner({
+          EDICTUM_SCHEMAS_DIR: rel,
+          EDICTUM_CONFORMANCE_REQUIRED: '1',
+        })
+        expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+        expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+        expect(result.output).toContain('zero rejection fixtures were loaded')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it(
+    'required mode: relative EDICTUM_SCHEMAS_DIR that misses cwd and repo root refuses fallthrough',
+    { timeout: 180_000 },
+    () => {
+      const result = runRunner({
+        EDICTUM_SCHEMAS_DIR: 'definitely-not-a-schemas-checkout-xyz',
+        EDICTUM_CONFORMANCE_REQUIRED: '1',
+      })
+      expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+      expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+      expect(result.output).toContain('refusing to fall through')
+      expect(result.output).toContain('Tried:')
     },
   )
 })

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -52,7 +52,10 @@ function runRunner(env: Record<string, string>): RunnerResult {
     cwd: CORE_ROOT,
     env: childEnv,
     encoding: 'utf8',
-    timeout: 120_000,
+    // Headroom inside the 180 s vitest test timeout: a child killed at its
+    // own deadline reports status null, which must fail every assertion
+    // below rather than satisfy `not.toBe(0)`.
+    timeout: 150_000,
   })
 
   return {
@@ -66,6 +69,11 @@ function makeEmptyRejectionDir(): string {
   const root = mkdtempSync(join(tmpdir(), 'edictum-gate-empty-'))
   mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
   return root
+}
+
+/** Create a temp schemas root with no fixtures tree at all (wrong-ref checkout shape). */
+function makeWrongRefRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'edictum-gate-wrongref-'))
 }
 
 /** Create a temp schemas root with one suite file whose fixtures lack expected.rejected. */
@@ -101,8 +109,28 @@ describe('shared rejection runner — fail-closed gates', () => {
           EDICTUM_SCHEMAS_DIR: root,
           EDICTUM_CONFORMANCE_REQUIRED: '1',
         })
+        expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
         expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
         expect(result.output).toContain('zero rejection fixtures were loaded')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it(
+    'required mode: EDICTUM_SCHEMAS_DIR set but wrong fails instead of falling through to other discoveries',
+    { timeout: 180_000 },
+    () => {
+      const root = makeWrongRefRoot()
+      try {
+        const result = runRunner({
+          EDICTUM_SCHEMAS_DIR: root,
+          EDICTUM_CONFORMANCE_REQUIRED: '1',
+        })
+        expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
+        expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+        expect(result.output).toContain('refusing to fall through')
       } finally {
         rmSync(root, { recursive: true, force: true })
       }
@@ -119,6 +147,7 @@ describe('shared rejection runner — fail-closed gates', () => {
           EDICTUM_SCHEMAS_DIR: root,
           EDICTUM_CONFORMANCE_REQUIRED: '1',
         })
+        expect(result.status, `runner output:\n${result.output}`).not.toBeNull()
         expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
         expect(result.output).toContain('missing a boolean expected.rejected')
       } finally {

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -15,12 +15,17 @@
  */
 
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { dirname, join, relative, resolve } from 'node:path'
+import { existsSync, rmSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
+
+import {
+  makeEmptyRejectionDir,
+  makeMissingExpectationDir,
+  makeWrongRefRoot,
+} from './conformance-gate-helpers.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const CORE_ROOT = resolve(HERE, '..', '..')
@@ -63,40 +68,6 @@ function runRunner(env: Record<string, string>): RunnerResult {
     status: result.status,
     output: `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
   }
-}
-
-/** Create a temp schemas root whose rejection directory exists but is empty. */
-function makeEmptyRejectionDir(): string {
-  const root = mkdtempSync(join(tmpdir(), 'edictum-gate-empty-'))
-  mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
-  return root
-}
-
-/** Create a temp schemas root with no fixtures tree at all (wrong-ref checkout shape). */
-function makeWrongRefRoot(): string {
-  return mkdtempSync(join(tmpdir(), 'edictum-gate-wrongref-'))
-}
-
-/** Create a temp schemas root with one suite file whose fixtures lack expected.rejected. */
-function makeMissingExpectationDir(): string {
-  const root = mkdtempSync(join(tmpdir(), 'edictum-gate-expect-'))
-  mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
-  writeFileSync(
-    join(root, 'fixtures', 'rejection', 'sabotage.rejection.yaml'),
-    [
-      'suite: sabotage',
-      'description: fixture entry with a misspelled expectation key',
-      'fixtures:',
-      '  - id: sab-001',
-      '    description: expectation key misspelled as rejectd',
-      '    bundle: {}',
-      '    expected:',
-      '      rejectd: true',
-      '      error_contains: whatever',
-      '',
-    ].join('\n'),
-  )
-  return root
 }
 
 describe('shared rejection runner — fail-closed gates', () => {
@@ -204,6 +175,21 @@ describe('shared rejection runner — fail-closed gates', () => {
       expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
       expect(result.output).toContain('refusing to fall through')
       expect(result.output).toContain('Tried:')
+    },
+  )
+
+  it(
+    'optional mode: wrong EDICTUM_SCHEMAS_DIR warns and falls back instead of failing',
+    { timeout: 180_000 },
+    () => {
+      const root = makeWrongRefRoot()
+      try {
+        const result = runRunner({ EDICTUM_SCHEMAS_DIR: root })
+        expect(result.status, `runner output:\n${result.output}`).toBe(0)
+        expect(result.output).toContain('falling back to repo-relative discovery')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
     },
   )
 })

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -56,13 +56,13 @@ function runRunner(env: Record<string, string>): RunnerResult {
   delete childEnv.EDICTUM_CONFORMANCE_REQUIRED
   Object.assign(childEnv, env)
 
-  const result = spawnSync(process.execPath, [VITEST_ENTRY, 'run', RUNNER_FILE], {
+  const vitestArgs = [VITEST_ENTRY, 'run', '--reporter=verbose', RUNNER_FILE]
+  const result = spawnSync(process.execPath, vitestArgs, {
     cwd: CORE_ROOT,
     env: childEnv,
     encoding: 'utf8',
-    // Headroom inside the 180 s vitest test timeout: a child killed at its
-    // own deadline reports status null, which must fail every assertion
-    // below rather than satisfy `not.toBe(0)`.
+    // Child timeout sits inside the 180 s test timeout. status null must
+    // fail every assertion below rather than satisfy not.toBe(0).
     timeout: 150_000,
   })
 
@@ -138,7 +138,9 @@ describe('shared rejection runner — fail-closed gates', () => {
       try {
         const result = runRunner({ EDICTUM_SCHEMAS_DIR: root })
         expect(result.status, `runner output:\n${result.output}`).toBe(0)
-        expect(result.output).toContain('1 skipped')
+        expect(result.output).toContain(
+          'shared rejection fixtures — edictum-schemas not found or empty',
+        )
       } finally {
         rmSync(root, { recursive: true, force: true })
       }

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for the fail-closed behavior of the shared rejection
+ * fixture runner (shared-fixtures.test.ts).
+ *
+ * The runner's discovery and required-mode gate execute at module import,
+ * so these checks cannot live inside the runner itself. Each test spawns
+ * the real test runner as a child process against a temporary fixtures
+ * tree and asserts on the exit status AND the specific rejection reason in
+ * the output — a non-zero exit alone would also pass on any unrelated
+ * crash.
+ *
+ * With the fail-closed behavior reverted (empty directory → silent skip;
+ * missing expected.rejected → inverted assertion), the children exit 0 and
+ * these tests go red.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const CORE_ROOT = resolve(HERE, '..', '..')
+const RUNNER_FILE = 'tests/yaml-engine/shared-fixtures.test.ts'
+const VITEST_BIN = join(CORE_ROOT, 'node_modules', '.bin', 'vitest')
+
+interface RunnerResult {
+  status: number | null
+  output: string
+}
+
+/**
+ * Run the real runner file under vitest with the conformance environment
+ * fully controlled by the caller — inherited EDICTUM_* variables are
+ * stripped so a parent conformance run cannot leak into the child.
+ */
+function runRunner(env: Record<string, string>): RunnerResult {
+  if (!existsSync(VITEST_BIN)) {
+    throw new Error(`vitest binary not found at ${VITEST_BIN} — run pnpm install first`)
+  }
+
+  const childEnv: NodeJS.ProcessEnv = { ...process.env }
+  delete childEnv.EDICTUM_SCHEMAS_DIR
+  delete childEnv.EDICTUM_FIXTURES_DIR
+  delete childEnv.EDICTUM_CONFORMANCE_REQUIRED
+  Object.assign(childEnv, env)
+
+  const result = spawnSync(VITEST_BIN, ['run', RUNNER_FILE], {
+    cwd: CORE_ROOT,
+    env: childEnv,
+    encoding: 'utf8',
+    timeout: 120_000,
+  })
+
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+  }
+}
+
+/** Create a temp schemas root whose rejection directory exists but is empty. */
+function makeEmptyRejectionDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-gate-empty-'))
+  mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
+  return root
+}
+
+/** Create a temp schemas root with one suite file whose fixtures lack expected.rejected. */
+function makeMissingExpectationDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'edictum-gate-expect-'))
+  mkdirSync(join(root, 'fixtures', 'rejection'), { recursive: true })
+  writeFileSync(
+    join(root, 'fixtures', 'rejection', 'sabotage.rejection.yaml'),
+    [
+      'suite: sabotage',
+      'description: fixture entry with a misspelled expectation key',
+      'fixtures:',
+      '  - id: sab-001',
+      '    description: expectation key misspelled as rejectd',
+      '    bundle: {}',
+      '    expected:',
+      '      rejectd: true',
+      '      error_contains: whatever',
+      '',
+    ].join('\n'),
+  )
+  return root
+}
+
+describe('shared rejection runner — fail-closed gates', () => {
+  it(
+    'required mode: empty rejection directory fails the run (not a silent skip)',
+    { timeout: 180_000 },
+    () => {
+      const root = makeEmptyRejectionDir()
+      try {
+        const result = runRunner({
+          EDICTUM_SCHEMAS_DIR: root,
+          EDICTUM_CONFORMANCE_REQUIRED: '1',
+        })
+        expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+        expect(result.output).toContain('zero rejection fixtures were loaded')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it(
+    'required mode: fixture missing expected.rejected fails the run (not an inverted assertion)',
+    { timeout: 180_000 },
+    () => {
+      const root = makeMissingExpectationDir()
+      try {
+        const result = runRunner({
+          EDICTUM_SCHEMAS_DIR: root,
+          EDICTUM_CONFORMANCE_REQUIRED: '1',
+        })
+        expect(result.status, `runner output:\n${result.output}`).not.toBe(0)
+        expect(result.output).toContain('missing a boolean expected.rejected')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it(
+    'optional mode: empty rejection directory stays a named skip, not a failure',
+    { timeout: 180_000 },
+    () => {
+      const root = makeEmptyRejectionDir()
+      try {
+        const result = runRunner({ EDICTUM_SCHEMAS_DIR: root })
+        expect(result.status, `runner output:\n${result.output}`).toBe(0)
+        expect(result.output).toContain('skipped')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    },
+  )
+})

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -138,7 +138,7 @@ describe('shared rejection runner — fail-closed gates', () => {
       try {
         const result = runRunner({ EDICTUM_SCHEMAS_DIR: root })
         expect(result.status, `runner output:\n${result.output}`).toBe(0)
-        expect(result.output).toContain('edictum-schemas not found or empty (optional mode)')
+        expect(result.output).toContain('1 skipped')
       } finally {
         rmSync(root, { recursive: true, force: true })
       }

--- a/packages/core/tests/yaml-engine/conformance-gate.test.ts
+++ b/packages/core/tests/yaml-engine/conformance-gate.test.ts
@@ -17,6 +17,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, rmSync } from 'node:fs'
 import { dirname, relative, resolve } from 'node:path'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
@@ -31,7 +32,8 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 const CORE_ROOT = resolve(HERE, '..', '..')
 const RUNNER_FILE = 'tests/yaml-engine/shared-fixtures.test.ts'
 const REPO_ROOT = resolve(CORE_ROOT, '..', '..')
-const VITEST_ENTRY = fileURLToPath(import.meta.resolve('vitest/vitest.mjs'))
+const require = createRequire(import.meta.url)
+const VITEST_ENTRY = require.resolve('vitest/vitest.mjs')
 
 interface RunnerResult {
   status: number | null

--- a/packages/core/tests/yaml-engine/shared-fixtures.test.ts
+++ b/packages/core/tests/yaml-engine/shared-fixtures.test.ts
@@ -194,24 +194,15 @@ const conformanceRequired = process.env.EDICTUM_CONFORMANCE_REQUIRED === '1'
 if (schemasEnv && !envHit) {
   if (conformanceRequired) {
     throw new Error(
-      'EDICTUM_SCHEMAS_DIR is set to "' +
-        schemasEnv +
-      '" but none of the resolved ' +
-        REJECTION_SUBPATH +
-      ' directories exist — refusing to fall through to ' +
-      'repo-relative discovery. Tried: ' +
-      envCandidates.join(', ') +
-      '. Fix the schemas checkout or unset the variable.',
+      `EDICTUM_SCHEMAS_DIR is set to "${schemasEnv}" but none of the resolved ` +
+        `${REJECTION_SUBPATH} directories exist — refusing to fall through to ` +
+        `repo-relative discovery. Tried: ${envCandidates.join(', ')}. ` +
+        'Fix the schemas checkout or unset the variable.',
     )
   }
   console.warn(
-    '[edictum] EDICTUM_SCHEMAS_DIR="' +
-      schemasEnv +
-      '" has no ' +
-      REJECTION_SUBPATH +
-      ' at tried paths [' +
-      envCandidates.join(', ') +
-      ']; falling back to repo-relative discovery.',
+    `[edictum] EDICTUM_SCHEMAS_DIR="${schemasEnv}" has no ${REJECTION_SUBPATH} ` +
+      `at tried paths [${envCandidates.join(', ')}]; falling back to repo-relative discovery.`,
   )
 }
 
@@ -224,12 +215,12 @@ const loadedFixtures = suites?.reduce((count, suite) => count + suite.fixtures.l
 // corpus) is a hard failure, never a green skip.
 if (conformanceRequired && loadedFixtures === 0) {
   const alreadySet = schemasEnv
-    ? 'EDICTUM_SCHEMAS_DIR is already set to "' + schemasEnv + '"'
+    ? `EDICTUM_SCHEMAS_DIR is already set to "${schemasEnv}"`
     : 'Set EDICTUM_SCHEMAS_DIR or check out edictum-schemas as a sibling'
   throw new Error(
     'EDICTUM_CONFORMANCE_REQUIRED=1 but zero rejection fixtures were loaded' +
-      (fixturesDir ? ' from ' + fixturesDir : ' — no rejection fixtures directory was found') +
-      '. Tried: ' + triedPaths.join(', ') + '. ' + alreadySet + '.',
+      (fixturesDir ? ` from ${fixturesDir}` : ' — no rejection fixtures directory was found') +
+      `. Tried: ${triedPaths.join(', ')}. ${alreadySet}.`,
   )
 }
 

--- a/packages/core/tests/yaml-engine/shared-fixtures.test.ts
+++ b/packages/core/tests/yaml-engine/shared-fixtures.test.ts
@@ -187,10 +187,10 @@ const triedPaths = [...envCandidates, ...FALLBACK_REJECTION_DIRS]
 const conformanceRequired = process.env.EDICTUM_CONFORMANCE_REQUIRED === '1'
 
 // An explicitly-set EDICTUM_SCHEMAS_DIR that does not resolve is never
-// silently stepped over (contract C5): a wrong pin or truncated checkout
-// must fail in required mode rather than quietly load whatever
-// nested/sibling directory happens to exist. Relative values are tried
-// from cwd and from the repo root before this refusal.
+// silently stepped over: a wrong pin or truncated checkout must fail in
+// required mode rather than quietly load whatever repo-relative directory
+// happens to exist. Relative values are tried from cwd and from the repo
+// root before this refusal.
 if (schemasEnv && !envHit) {
   if (conformanceRequired) {
     throw new Error(

--- a/packages/core/tests/yaml-engine/shared-fixtures.test.ts
+++ b/packages/core/tests/yaml-engine/shared-fixtures.test.ts
@@ -3,7 +3,10 @@
  * cross-SDK rejection corpus maintained in edictum-schemas.
  *
  * Fixture discovery (first match wins):
- *   1. EDICTUM_SCHEMAS_DIR env var (root of edictum-schemas repo)
+ *   1. EDICTUM_SCHEMAS_DIR env var (root of edictum-schemas repo). A relative
+ *      value is resolved against cwd and then the repo root, so
+ *      a relative edictum-schemas value still works when core tests run
+ *      with cwd packages/core.
  *   2. <repo-root>/edictum-schemas/ (monorepo / vendored checkout)
  *   3. <repo-root>/../edictum-schemas/ (sibling checkout)
  *
@@ -43,24 +46,22 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(HERE, '..', '..', '..', '..')
 const REJECTION_SUBPATH = join('fixtures', 'rejection')
 
-/** Resolve the rejection fixtures directory using the discovery order. */
-function resolveFixturesDir(): string | null {
-  // 1. Schemas repo root via env var
-  const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
-  if (schemasEnv) {
-    const candidate = join(schemasEnv, REJECTION_SUBPATH)
-    if (existsSync(candidate)) return candidate
+const FALLBACK_REJECTION_DIRS = [
+  join(REPO_ROOT, 'edictum-schemas', REJECTION_SUBPATH),
+  resolve(REPO_ROOT, '..', 'edictum-schemas', REJECTION_SUBPATH),
+]
+
+function firstExisting(paths: readonly string[]): string | null {
+  for (const p of paths) {
+    if (existsSync(p)) return p
   }
-
-  // 2. Nested inside repo root (monorepo / vendored)
-  const nested = join(REPO_ROOT, 'edictum-schemas', REJECTION_SUBPATH)
-  if (existsSync(nested)) return nested
-
-  // 3. Sibling checkout
-  const sibling = resolve(REPO_ROOT, '..', 'edictum-schemas', REJECTION_SUBPATH)
-  if (existsSync(sibling)) return sibling
-
   return null
+}
+
+function envRejectionCandidates(schemasEnv: string): string[] {
+  const fromCwd = resolve(process.cwd(), schemasEnv, REJECTION_SUBPATH)
+  const fromRoot = resolve(REPO_ROOT, schemasEnv, REJECTION_SUBPATH)
+  return fromCwd === fromRoot ? [fromCwd] : [fromCwd, fromRoot]
 }
 
 // ---------------------------------------------------------------------------
@@ -178,40 +179,57 @@ function loadFixtureSuites(dir: string): FixtureSuite[] {
 // Runner
 // ---------------------------------------------------------------------------
 
-const fixturesDir = resolveFixturesDir()
+const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
+const envCandidates = schemasEnv ? envRejectionCandidates(schemasEnv) : []
+const envHit = firstExisting(envCandidates)
+const fallbackHit = firstExisting(FALLBACK_REJECTION_DIRS)
+const triedPaths = [...envCandidates, ...FALLBACK_REJECTION_DIRS]
 const conformanceRequired = process.env.EDICTUM_CONFORMANCE_REQUIRED === '1'
-const suites = fixturesDir ? loadFixtureSuites(fixturesDir) : null
-const loadedFixtures = suites?.reduce((count, suite) => count + suite.fixtures.length, 0) ?? 0
 
 // An explicitly-set EDICTUM_SCHEMAS_DIR that does not resolve is never
 // silently stepped over (contract C5): a wrong pin or truncated checkout
 // must fail in required mode rather than quietly load whatever
-// nested/sibling directory happens to exist — a corpus mismatch that
-// reads as a pass.
-const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
-if (schemasEnv && !existsSync(join(schemasEnv, REJECTION_SUBPATH))) {
+// nested/sibling directory happens to exist. Relative values are tried
+// from cwd and from the repo root before this refusal.
+if (schemasEnv && !envHit) {
   if (conformanceRequired) {
     throw new Error(
-      `EDICTUM_SCHEMAS_DIR is set to "${schemasEnv}" but ` +
-        `${join(schemasEnv, REJECTION_SUBPATH)} does not exist — ` +
-        'refusing to fall through to repo-relative discovery. ' +
-        'Fix the schemas checkout or unset the variable.',
+      'EDICTUM_SCHEMAS_DIR is set to "' +
+        schemasEnv +
+      '" but none of the resolved ' +
+        REJECTION_SUBPATH +
+      ' directories exist — refusing to fall through to ' +
+      'repo-relative discovery. Tried: ' +
+      envCandidates.join(', ') +
+      '. Fix the schemas checkout or unset the variable.',
     )
   }
   console.warn(
-    `[edictum] EDICTUM_SCHEMAS_DIR="${schemasEnv}" has no ${REJECTION_SUBPATH}; ` +
-      'falling back to repo-relative discovery.',
+    '[edictum] EDICTUM_SCHEMAS_DIR="' +
+      schemasEnv +
+      '" has no ' +
+      REJECTION_SUBPATH +
+      ' at tried paths [' +
+      envCandidates.join(', ') +
+      ']; falling back to repo-relative discovery.',
   )
 }
+
+const fixturesDir = envHit ?? fallbackHit
+const suites = fixturesDir ? loadFixtureSuites(fixturesDir) : null
+const loadedFixtures = suites?.reduce((count, suite) => count + suite.fixtures.length, 0) ?? 0
 
 // Required-mode gate on the loaded fixture list, not on the directory: a
 // resolved-but-empty directory (truncated checkout, wrong ref, moved
 // corpus) is a hard failure, never a green skip.
 if (conformanceRequired && loadedFixtures === 0) {
+  const alreadySet = schemasEnv
+    ? 'EDICTUM_SCHEMAS_DIR is already set to "' + schemasEnv + '"'
+    : 'Set EDICTUM_SCHEMAS_DIR or check out edictum-schemas as a sibling'
   throw new Error(
     'EDICTUM_CONFORMANCE_REQUIRED=1 but zero rejection fixtures were loaded' +
-      (fixturesDir ? ` from ${fixturesDir}` : ' — no rejection fixtures directory was found') +
-      '. Set EDICTUM_SCHEMAS_DIR or check out edictum-schemas as a sibling.',
+      (fixturesDir ? ' from ' + fixturesDir : ' — no rejection fixtures directory was found') +
+      '. Tried: ' + triedPaths.join(', ') + '. ' + alreadySet + '.',
   )
 }
 

--- a/packages/core/tests/yaml-engine/shared-fixtures.test.ts
+++ b/packages/core/tests/yaml-engine/shared-fixtures.test.ts
@@ -3,17 +3,26 @@
  * cross-SDK rejection corpus maintained in edictum-schemas.
  *
  * Fixture discovery (first match wins):
- *   1. EDICTUM_FIXTURES_DIR env var (direct path to rejection/ directory)
- *   2. EDICTUM_SCHEMAS_DIR env var (root of edictum-schemas repo)
- *   3. <repo-root>/edictum-schemas/ (monorepo / vendored checkout)
- *   4. <repo-root>/../edictum-schemas/ (sibling checkout)
+ *   1. EDICTUM_SCHEMAS_DIR env var (root of edictum-schemas repo)
+ *   2. <repo-root>/edictum-schemas/ (monorepo / vendored checkout)
+ *   3. <repo-root>/../edictum-schemas/ (sibling checkout)
  *
- * Missing-fixture behavior:
- *   - EDICTUM_CONFORMANCE_REQUIRED=1 → fail the test run
- *   - Otherwise → skip the suite cleanly
+ * EDICTUM_FIXTURES_DIR is no longer read: it once meant the fixtures root
+ * here and the rejection/ subdirectory in other runners, so one name
+ * silently selected different directories per SDK.
+ *
+ * Missing-fixture behavior — gated on the LOADED fixture list, not on the
+ * directory existing:
+ *   - EDICTUM_CONFORMANCE_REQUIRED=1 with zero loadable fixtures (missing
+ *     directory, empty directory, or files carrying no fixtures) → fail
+ *     the test run
+ *   - Otherwise → skip the suite cleanly (a named skip, never a pass)
  *
  * Each fixture provides a bundle that must be rejected by the loader, plus
- * an `error_contains` substring that the error message must include.
+ * an `error_contains` substring that the error message must include. A
+ * fixture entry whose `expected.rejected` is absent or not a boolean is a
+ * hard failure at load time: a missing or misspelled expectation must
+ * never silently invert into "must load successfully".
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
@@ -36,22 +45,18 @@ const REJECTION_SUBPATH = join('fixtures', 'rejection')
 
 /** Resolve the rejection fixtures directory using the discovery order. */
 function resolveFixturesDir(): string | null {
-  // 1. Direct path via env var
-  const fixturesEnv = process.env.EDICTUM_FIXTURES_DIR
-  if (fixturesEnv && existsSync(fixturesEnv)) return fixturesEnv
-
-  // 2. Schemas repo root via env var
+  // 1. Schemas repo root via env var
   const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
   if (schemasEnv) {
     const candidate = join(schemasEnv, REJECTION_SUBPATH)
     if (existsSync(candidate)) return candidate
   }
 
-  // 3. Nested inside repo root (monorepo / vendored)
+  // 2. Nested inside repo root (monorepo / vendored)
   const nested = join(REPO_ROOT, 'edictum-schemas', REJECTION_SUBPATH)
   if (existsSync(nested)) return nested
 
-  // 4. Sibling checkout
+  // 3. Sibling checkout
   const sibling = resolve(REPO_ROOT, '..', 'edictum-schemas', REJECTION_SUBPATH)
   if (existsSync(sibling)) return sibling
 
@@ -126,13 +131,14 @@ function normalizeExpectedErrorSubstring(value: string): string {
   return value
 }
 
-function loadFixtureSuites(dir: string): FixtureSuite[] | null {
+function loadFixtureSuites(dir: string): FixtureSuite[] {
   const files = readdirSync(dir)
     .filter((f) => f.endsWith('.rejection.yaml'))
     .sort()
 
-  if (files.length === 0) return null
-
+  // An empty directory is returned as zero suites — the required-mode gate
+  // below rejects on the loaded fixture count, so an empty checkout fails
+  // instead of silently skipping.
   return files.map((file) => {
     const content = readFileSync(join(dir, file), 'utf-8')
 
@@ -153,7 +159,18 @@ function loadFixtureSuites(dir: string): FixtureSuite[] | null {
       throw new Error(`Fixture file ${file} is missing a 'fixtures' array`)
     }
 
-    return parsed as FixtureSuite
+    const suite = parsed as FixtureSuite
+    for (const fixture of suite.fixtures) {
+      const expected = fixture?.expected as { rejected?: unknown } | undefined
+      if (expected == null || typeof expected.rejected !== 'boolean') {
+        throw new Error(
+          `Fixture file ${file}: fixture ${fixture?.id ?? '(missing id)'} is missing a boolean ` +
+            `expected.rejected — a missing or misspelled expectation must fail the suite, ` +
+            `not silently invert the assertion into "must load successfully"`,
+        )
+      }
+    }
+    return suite
   })
 }
 
@@ -163,17 +180,21 @@ function loadFixtureSuites(dir: string): FixtureSuite[] | null {
 
 const fixturesDir = resolveFixturesDir()
 const conformanceRequired = process.env.EDICTUM_CONFORMANCE_REQUIRED === '1'
+const suites = fixturesDir ? loadFixtureSuites(fixturesDir) : null
+const loadedFixtures = suites?.reduce((count, suite) => count + suite.fixtures.length, 0) ?? 0
 
-if (!fixturesDir && conformanceRequired) {
+// Required-mode gate on the loaded fixture list, not on the directory: a
+// resolved-but-empty directory (truncated checkout, wrong ref, moved
+// corpus) is a hard failure, never a green skip.
+if (conformanceRequired && loadedFixtures === 0) {
   throw new Error(
-    'EDICTUM_CONFORMANCE_REQUIRED=1 but no rejection fixtures found. ' +
-      'Set EDICTUM_FIXTURES_DIR or EDICTUM_SCHEMAS_DIR, or check out edictum-schemas as a sibling.',
+    'EDICTUM_CONFORMANCE_REQUIRED=1 but zero rejection fixtures were loaded' +
+      (fixturesDir ? ` from ${fixturesDir}` : ' — no rejection fixtures directory was found') +
+      '. Set EDICTUM_SCHEMAS_DIR or check out edictum-schemas as a sibling.',
   )
 }
 
-const suites = fixturesDir ? loadFixtureSuites(fixturesDir) : null
-
-if (suites) {
+if (suites && loadedFixtures > 0) {
   describe('shared rejection fixtures (edictum-schemas)', () => {
     for (const suite of suites) {
       if (!Array.isArray(suite.fixtures)) {
@@ -222,5 +243,5 @@ if (suites) {
     }
   })
 } else {
-  it.skip('shared rejection fixtures — edictum-schemas not found', () => {})
+  it.skip('shared rejection fixtures — edictum-schemas not found or empty (optional mode)', () => {})
 }

--- a/packages/core/tests/yaml-engine/shared-fixtures.test.ts
+++ b/packages/core/tests/yaml-engine/shared-fixtures.test.ts
@@ -183,6 +183,27 @@ const conformanceRequired = process.env.EDICTUM_CONFORMANCE_REQUIRED === '1'
 const suites = fixturesDir ? loadFixtureSuites(fixturesDir) : null
 const loadedFixtures = suites?.reduce((count, suite) => count + suite.fixtures.length, 0) ?? 0
 
+// An explicitly-set EDICTUM_SCHEMAS_DIR that does not resolve is never
+// silently stepped over (contract C5): a wrong pin or truncated checkout
+// must fail in required mode rather than quietly load whatever
+// nested/sibling directory happens to exist — a corpus mismatch that
+// reads as a pass.
+const schemasEnv = process.env.EDICTUM_SCHEMAS_DIR
+if (schemasEnv && !existsSync(join(schemasEnv, REJECTION_SUBPATH))) {
+  if (conformanceRequired) {
+    throw new Error(
+      `EDICTUM_SCHEMAS_DIR is set to "${schemasEnv}" but ` +
+        `${join(schemasEnv, REJECTION_SUBPATH)} does not exist — ` +
+        'refusing to fall through to repo-relative discovery. ' +
+        'Fix the schemas checkout or unset the variable.',
+    )
+  }
+  console.warn(
+    `[edictum] EDICTUM_SCHEMAS_DIR="${schemasEnv}" has no ${REJECTION_SUBPATH}; ` +
+      'falling back to repo-relative discovery.',
+  )
+}
+
 // Required-mode gate on the loaded fixture list, not on the directory: a
 // resolved-but-empty directory (truncated checkout, wrong ref, moved
 // corpus) is a hard failure, never a green skip.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/core:
@@ -83,7 +83,7 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/langchain:
@@ -111,7 +111,7 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/openai-agents:
@@ -139,7 +139,7 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/otel:
@@ -187,7 +187,7 @@ importers:
         specifier: ^8.0.0
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/server:
@@ -211,7 +211,7 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/vercel-ai:
@@ -239,7 +239,7 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.7
+        specifier: ^3.0.0
         version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
 packages:
@@ -2468,6 +2468,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -52,8 +52,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -72,7 +72,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typedoc:
         specifier: ^0.28.17
         version: 0.28.18(typescript@5.9.3)
@@ -83,8 +83,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/langchain:
     dependencies:
@@ -103,7 +103,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -111,8 +111,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/openai-agents:
     dependencies:
@@ -131,7 +131,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -139,8 +139,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/otel:
     devDependencies:
@@ -179,7 +179,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -187,8 +187,8 @@ importers:
         specifier: ^8.0.0
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/server:
     devDependencies:
@@ -203,7 +203,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -211,8 +211,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
   packages/vercel-ai:
     dependencies:
@@ -231,7 +231,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -239,8 +239,8 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
 packages:
 
@@ -275,8 +275,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -287,8 +299,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -299,8 +323,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -311,8 +347,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -323,8 +371,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -335,8 +395,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -347,8 +419,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -359,8 +443,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -371,8 +467,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -383,8 +491,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -395,8 +515,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -407,8 +539,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -419,8 +563,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -676,6 +832,12 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
   '@openai/agents-core@0.7.1':
     resolution: {integrity: sha512-GdYK9g03t4UCTnsd+nA7/YjXj3lk2e2TaWbo9Vs1btkSlqOguJA8maVwadypBGAdDIvr2LUp/H8jbMP3rv5t5Q==}
     peerDependencies:
@@ -822,8 +984,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.59.0':
     resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
     cpu: [arm64]
     os: [android]
 
@@ -832,8 +1004,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.59.0':
     resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
     cpu: [x64]
     os: [darwin]
 
@@ -842,8 +1024,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.59.0':
     resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
     cpu: [x64]
     os: [freebsd]
 
@@ -852,8 +1044,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
 
@@ -862,8 +1064,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
 
@@ -872,8 +1084,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
 
@@ -882,8 +1104,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
 
@@ -892,8 +1124,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
 
@@ -902,8 +1144,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
 
@@ -912,8 +1164,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
     cpu: [x64]
     os: [openbsd]
 
@@ -922,8 +1184,18 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rollup/rollup-win32-arm64-msvc@4.59.0':
     resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
     cpu: [arm64]
     os: [win32]
 
@@ -932,13 +1204,28 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-gnu@4.59.0':
     resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
     cpu: [x64]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
     cpu: [x64]
     os: [win32]
 
@@ -971,6 +1258,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1056,11 +1346,11 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -1070,20 +1360,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1326,6 +1616,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1422,8 +1717,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.1:
@@ -1752,8 +2047,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1860,6 +2155,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -1889,8 +2188,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1952,6 +2251,11 @@ packages:
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2067,6 +2371,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2179,8 +2487,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2219,16 +2527,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2348,79 +2656,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0(jiti@2.6.1))':
@@ -2687,6 +3073,9 @@ snapshots:
       - supports-color
     optional: true
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@openai/agents-core@0.7.1(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       debug: 4.4.3
@@ -2871,76 +3260,151 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
   '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
   '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
   '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     optional: true
 
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
   '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
   '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.59.0':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
   '@rollup/rollup-win32-x64-gnu@4.59.0':
     optional: true
 
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
   '@shikijs/engine-oniguruma@3.23.0':
@@ -2975,6 +3439,8 @@ snapshots:
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -3140,45 +3606,45 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 7.3.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@3.2.7':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@3.2.7':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 3.2.7
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
+  '@vitest/spy@3.2.7':
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -3433,6 +3899,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3:
@@ -3560,7 +4055,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -3578,7 +4073,7 @@ snapshots:
       eventsource-parser: 3.0.6
     optional: true
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
@@ -3632,6 +4127,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -3931,7 +4430,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4019,6 +4518,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.1:
@@ -4030,17 +4531,17 @@ snapshots:
       mlly: 1.8.1
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.26)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.26
       yaml: 2.8.2
 
-  postcss@8.5.8:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4129,6 +4630,38 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.59.0
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -4277,6 +4810,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
@@ -4294,7 +4832,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.26)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -4305,7 +4843,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.26)(yaml@2.8.2)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -4314,7 +4852,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.26
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -4394,7 +4932,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 7.3.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4409,43 +4947,43 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
+  vite@7.3.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.2
 
-  vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
+  vitest@3.2.7(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
-      expect-type: 1.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 7.3.6(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## What

Three fail-open seams in the shared rejection fixture runner (`packages/core/tests/yaml-engine/shared-fixtures.test.ts`), all fixed to fail closed:

1. **Empty directory silently skipped the suite even under `EDICTUM_CONFORMANCE_REQUIRED=1`** — `loadFixtureSuites` returned `null` on zero files (`:134`), and the required gate only fired when the *directory* was missing (`:167`). A truncated or wrong-ref checkout stayed green.
2. **The required gate checked the directory, not the loaded fixture list.** It now rejects when the loaded fixture count is zero — missing dir, empty dir, or files carrying no fixtures all fail, with the resolved directory named in the message.
3. **A missing or misspelled `expected.rejected` silently inverted the assertion** — `if (!fixture.expected.rejected)` treated an absent field as "must load successfully" (`:191`). Every fixture entry is now validated at load time to carry a *boolean* `expected.rejected`; anything else fails the whole suite before a single assertion runs. An explicit `rejected: false` remains a legitimate "must load" expectation.

Also: the runner no longer reads `EDICTUM_FIXTURES_DIR` — sdk-gate exported it as the fixtures *root* while this runner read it as the *rejection subdirectory*, so one name selected different directories per consumer (spec 02 fact 14). `EDICTUM_SCHEMAS_DIR` is the only fixture-location variable.

## Regression tests (subprocess mechanics — spec 02 §3)

The gate runs at module import, so the checks cannot live inside the runner. `tests/yaml-engine/conformance-gate.test.ts` spawns the real runner under vitest as a child process against sabotaged temp fixture trees, with inherited `EDICTUM_*` env stripped, and asserts exit status **and** the specific rejection reason:

- empty `fixtures/rejection/` + `EDICTUM_CONFORMANCE_REQUIRED=1` → exit ≠ 0, output contains `zero rejection fixtures were loaded`
- fixture with `rejectd: true` (misspelled key) + required → exit ≠ 0, output contains `missing a boolean expected.rejected`
- empty dir in optional mode → exit 0, named skip preserved (a revert that turns the loud skip into a failure also goes red)

**Revert check (run before pushing):** restored `shared-fixtures.test.ts` to `be80cbc`, kept the regression tests, ran them:

```
 ❯ tests/yaml-engine/conformance-gate.test.ts (3 tests | 2 failed)
   × required mode: empty rejection directory fails the run (not a silent skip)
   × required mode: fixture missing expected.rejected fails the run (not an inverted assertion)
   ✓ optional mode: empty rejection directory stays a named skip, not a failure
```

The second failure's output shows the original defect live: the child run of the sabotaged fixture produced `AssertionError: expected [Function] to not throw an error but 'EdictumConfigError: Schema validation failed…' was thrown` — the misspelled expectation had inverted the assertion into "must load successfully". Both tests go green again with the fix applied (`3 passed`).

## Green (run before pushing)

- Full core suite under the exact new CI conditions — absolute `EDICTUM_SCHEMAS_DIR` at the new pin + `EDICTUM_CONFORMANCE_REQUIRED=1`: **40 files / 844 tests passed** (841 known superset + 3 new gate tests). The pin bump surfaces no fixture divergence in TS.
- Runner against the real corpus in required mode: **42 passed**.
- `pnpm -r build`, `pnpm -r lint`, `pnpm format:check`, `pnpm -r typecheck`, all workspace tests — clean (pre-commit ran them).

## parity-check.yml — the consuming half of the sdk-gate fix

- `uses:` pin `a8b075f` → `d82a6556454dd3707043cc21a728569397693de4` — the edictum-ai/.github#9 commit that exports absolute `EDICTUM_SCHEMAS_DIR` and retires `EDICTUM_FIXTURES_DIR`.
- Inline relative `EDICTUM_SCHEMAS_DIR=edictum-schemas` deleted — it shadowed the workflow's export with a path that only resolved via the runner's nested-checkout fallback.
- `fixture-ref` `bfb633c` → `59df5f7f029f7ddcde35e35343405a62c7a405ce` — the manifest-bearing edictum-schemas#25 head. `bfb633c` (2026-03-28) predates every workflow fixture; the manifest is the C11/C14 anchor.

**Merge choreography (spec 02 §4.4):** pins must be exact SHAs that exist on `main`. **Updated:** edictum-ai/.github#9 was squash-merged as `8dcbbf351385ad493929531f4181aa0616a8dfe6` (the branch-head `d82a655` never reached main), so commit `e5f335d` repoints the `uses:` pin at the landed SHA — verified to carry the identical sdk-gate diff. The `fixture-ref` (`59df5f7…`) is still the branch head of edictum-schemas#25 and is **repointed the same way once that PR lands** (squash ⇒ use the landed main SHA). `actionlint` clean.

**CI note (updated):** the earlier red `ci` check was `pnpm audit --audit-level=critical` failing on GHSA-5xrq-8626-4rwp (vitest <3.2.6) — pre-existing on clean main, failing every PR opened in the repo. Commits `fdec496` + `2215709` move the lockfile to vitest 3.2.7 (manifests unchanged at `^3.0.0`): audit now exits 0 with zero critical findings and the full workspace suite passes on 3.2.7.


## Sibling sweep — every conformance runner, three SDKs, four fail-closed questions

(a) missing dir in required mode, (b) empty dir, (c) unparseable fixture, (d) missing expectation field. Full table with file:line citations in edictum-schemas#25. Position of this PR:

- **Fixed here:** row 1 — TS rejection runner (a ✓ b ✓ c ✓ d ✓ now), plus row 14 (TS `parity-check.yml` pins + inline env).
- **Correct already (reference patterns):** Python `test_rejection.py:154` (this fix mirrors it), Python `test_workflow_adapter.py:107`, Go `TestSharedRejectionFixtures_Discovery`, Go adapter runner's zero-file `Fatalf`.
- **Same-repo siblings NOT fixed here, with owner named:** TS `workflow-v018-conformance.test.ts` has **no required gate at all**; TS `workflow-adapter-conformance.test.ts` gates on `EDICTUM_WORKFLOW_ADAPTER_CONFORMANCE_REQUIRED` which no CI sets, silently skips on empty dir even under its own flag, and **skips the decision assertion entirely** when `step.expect` lacks `decision` (`if ('decision' in step.expect)`); both retire `EDICTUM_WORKFLOW_ADAPTER_FIXTURES_DIR` → **spec 02 PR 6a (Lane 2)**. TS `ci.yml` `pnpm test -- --grep "security"` drops the filter (the 841-superset accident; `--grep` is not a vitest flag) → **spec 02 PR 5 (Lane 2)**. Note: the parity conformance-command's own `--` filter drop is why the "42 fixtures" evidence above was re-measured with an explicit file argument.
- **Other-SDK mirrors, named:** Python v0.18 dir-only gate (`test_workflow_v018.py:56`) → **spec 02 PR 4** (this session). Go's two workflow runners plain-`t.Skip` + Go rejection runner's zero-valued `Rejected bool` + Go's inline `parity-check.yml` env → **spec 02 PR 9 (Lane 2, after the wt-003 fix PR 8)**. sdk-gate env semantics → **PR 2, landed as edictum-ai/.github#9**.

## The green that does not count

A passing Parity Check after this PR proves the rejection runner loads its fixtures and fails when it cannot — under an absolute env var, at a manifest-bearing pin. It does not prove conformance across the three SDKs, and the workflow suites this repo runs in the same job (v0.18, workflow-adapter) remain ungated until spec 02 PR 6a. Nothing here may be cited as "all three SDKs behave the same".

