### PR TITLE
docs: drop archived api/app/openclaw listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,8 +211,6 @@ Edictum spans multiple repos that work together:
 - **edictum** (core Python): `edictum-ai/edictum` — MIT Python library. PyPI: `edictum`.
 - **edictum-ts** (core TypeScript): THIS REPO — MIT TypeScript library. npm: `@edictum/core`.
 - **edictum-go** (core Go): `edictum-ai/edictum-go` — Go SDK and CLI.
-- **edictum-api** (control-plane API): `edictum-ai/edictum-api` — hosted backend for runs, approvals, notifications, and audit.
-- **edictum-app** (control-plane UI): `edictum-ai/edictum-app` — hosted frontend for runs, approvals, policies, and settings.
 - **edictum-schemas** (shared): `edictum-ai/edictum-schemas` — Shared schema and conformance fixtures.
 
 The SDKs work standalone. The control plane is optional. The schema repo is the single source of truth for shared formats and fixtures.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,6 @@ Every security boundary has bypass tests. Every error path fails closed. Every i
 | [edictum](https://github.com/edictum-ai/edictum)                 | Python      | Reference implementation (PyPI: `edictum`) |
 | [edictum-ts](https://github.com/edictum-ai/edictum-ts)           | TypeScript  | This repo                                  |
 | [edictum-go](https://github.com/edictum-ai/edictum-go)           | Go          | Full port + adapters                       |
-| [edictum-api](https://github.com/edictum-ai/edictum-api)         | Go          | Hosted control-plane API                   |
-| [edictum-app](https://github.com/edictum-ai/edictum-app)         | React       | Hosted control-plane UI                    |
 | [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | JSON Schema | Shared ruleset schema                      |
 | [edictum-demo](https://github.com/edictum-ai/edictum-demo)       | Python      | Demos, adversarial tests, benchmarks       |
 


### PR DESCRIPTION
## Summary
- Drop `edictum-api` / `edictum-app` rows from the README ecosystem table
- Drop those control-plane repo bullets from `CLAUDE.md`

## Test plan
- [ ] Confirm README ecosystem table no longer links archived api/app repos
- [ ] Confirm `CLAUDE.md` ecosystem list no longer names those repos