### PR TITLE
fix(claude-sdk): admit empty PreToolUse hook output

### DIFF
--- a/packages/claude-sdk/src/index.ts
+++ b/packages/claude-sdk/src/index.ts
@@ -147,7 +147,7 @@ export type HookMatcher = HookCallbackMatcher
 export type PreToolUseInput = SDKPreToolUseHookInput
 export type PostToolUseInput = SDKPostToolUseHookInput
 export type PostToolUseFailureInput = SDKPostToolUseFailureHookInput
-export type PreToolUseHookOutput = { hookSpecificOutput: PreToolUseHookSpecificOutput }
+export type PreToolUseHookOutput = { hookSpecificOutput?: PreToolUseHookSpecificOutput }
 export type PostToolUseHookOutput = { hookSpecificOutput?: PostToolUseHookSpecificOutput }
 export type PostToolUseFailureHookOutput = {
   hookSpecificOutput?: PostToolUseFailureHookSpecificOutput

--- a/packages/claude-sdk/tests/adapter.test.ts
+++ b/packages/claude-sdk/tests/adapter.test.ts
@@ -801,13 +801,14 @@ describe('toSdkHooks', () => {
     const adapter = new ClaudeAgentSDKAdapter(guard)
     const options = { hooks: adapter.toSdkHooks() } satisfies Pick<Options, 'hooks'>
 
-    const result = await sdkCallback(options, 'PreToolUse')(
+    const result: PreToolUseHookOutput = await sdkCallback(options, 'PreToolUse')(
       preInput('MyTool', {}),
       'call-1',
       hookContext,
     )
 
     expect(result).toEqual({})
+    expect(result.hookSpecificOutput).toBeUndefined()
   })
 
   it.each([null, [], 'string', 42])(


### PR DESCRIPTION
## Summary
- `PreToolUseHookOutput.hookSpecificOutput` is optional, matching PostToolUse / PostToolUseFailure
- Passing PreToolUse still returns `{}`; test asserts `hookSpecificOutput` is undefined
- Follow-up for the P2 left open on #179

## Test plan
- [ ] CI green
- [ ] Codex clean